### PR TITLE
Fix broken links and link-formatting in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,11 @@ Famo.us is a framework that is always testing the limits of where browsers can g
 If you think you've encountered a bug, do the following:
 
 1. Make sure you are working with the latest version of the Famo.us `master` branch.
-2. Browse through the [issues][#issues] to check if
+2. Browse through the [issues](#issues) to check if
    anyone else has already reported. If someone has, feel free to add more
    information to that issue to help us solve it.
 3. If no one has yet submitted the issue you are encountering, check the
-   [guidelines for deciding where to file your issue][#issues]. Please be sure
+   [guidelines for deciding where to file your issue](#issues). Please be sure
    to include as much information as possible, include errors, warnings,
    screenshots, links to a video showing the problem or code that can reproduce
    the issue.
@@ -37,7 +37,7 @@ hiccups.
 
 Our development process is very similar to the approach
 described in the well-known article [A Successful Git Branching Model by Vincent
-Driessen][git_branching_model]. Here's a 10,000 foot overview:
+Driessen][git-branching-model]. Here's a 10,000 foot overview:
 
 * Our `master` branch is the branch upon which most
   famous developers should be basing their work on. The `master` branch is not guaranteed to be stable.
@@ -86,7 +86,7 @@ branch. We are using the following tokens:
     wip   // work in progress
     feat  // feature
 
-Bug fixes follow a [slightly different format][#bug-fixes].
+Bug fixes follow a [slightly different format](#bug-fixes).
 
 
 ### Bug fixes


### PR DESCRIPTION
Many of the links in CONTRIBUTING.md where broken because of bad link-formatting or mis-spellings.

Before:

![screen shot 2014-04-27 at 5 45 05 pm](https://cloud.githubusercontent.com/assets/4745181/2812775/60640492-ce6e-11e3-8457-e7f20267b69f.png)

After:

![screen shot 2014-04-27 at 5 45 41 pm](https://cloud.githubusercontent.com/assets/4745181/2812778/73f734ac-ce6e-11e3-99cb-9694b91cb2cb.png)

This PR fixes most of these issues. There is one link on line 95 that I just don't know where to direct to because there's nothing similar to it in the links on the bottom of the document.
