### PR TITLE
[Fix] Enable chaining for transitionable.halt()

### DIFF
--- a/transitions/Transitionable.js
+++ b/transitions/Transitionable.js
@@ -206,7 +206,7 @@ define(function(require, exports, module) {
      * @method halt
      */
     Transitionable.prototype.halt = function halt() {
-        this.set(this.get());
+        return this.set(this.get());
     };
 
     module.exports = Transitionable;


### PR DESCRIPTION
I noticed that I can't do `transitionable.halt().set(...)`
