### PR TITLE
Allow Engine to initialize without document.body

### DIFF
--- a/core/Engine.js
+++ b/core/Engine.js
@@ -129,8 +129,6 @@ define(function(require, exports, module) {
         window.addEventListener('touchmove', function(event) {
             event.preventDefault();
         }, true);
-        document.body.classList.add('famous-root');
-        document.documentElement.classList.add('famous-root');
     }
     var initialized = false;
 

--- a/core/famous.css
+++ b/core/famous.css
@@ -7,7 +7,7 @@
  * @copyright Famous Industries, Inc. 2014
  */
 
-.famous-root {
+html, body {
     width: 100%;
     height: 100%;
     margin: 0px;


### PR DESCRIPTION
This way we can define the engine before document.body exists.
