### PR TITLE
Easing.js Documentation 

### DIFF
--- a/transitions/Easing.js
+++ b/transitions/Easing.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
 
-    /*
+    /**
      * A library of curves which map an animation explicitly as a function of time.
      *
      * @class Easing


### PR DESCRIPTION
The missing \* prevents YUIDoc from parsing Easing.js as a part of the library. With this addition, the next time the documentation is generated, Easing will show up!
