### PR TITLE
guard for pre-commited size

### DIFF
--- a/core/Surface.js
+++ b/core/Surface.js
@@ -358,7 +358,7 @@ define(function(require, exports, module) {
      * @return {Array.Number} [x,y] size of surface
      */
     Surface.prototype.getSize = function getSize() {
-        return this._size;
+        return this._size ? this._size : this.size;
     };
 
     /**


### PR DESCRIPTION
If you set a surface's size, before the surface is committed to the DOM, `getSize` will return `null`. This change allows Surface to return the size set by the user. 

@michaelobriena
