### PR TITLE
RFC: Remove added to context, view, rendernode

### DIFF
--- a/core/Context.js
+++ b/core/Context.js
@@ -34,7 +34,7 @@ define(function(require, exports, module) {
         this.container = container;
         this._allocator = new ElementAllocator(container);
 
-        this._node = new RenderNode();
+        this._node = new RenderNode(this);
         this._eventOutput = new EventHandler();
         this._size = _getElementSize(this.container);
 
@@ -71,6 +71,19 @@ define(function(require, exports, module) {
      */
     Context.prototype.add = function add(obj) {
         return this._node.add(obj);
+    };
+
+    /**
+     * Remove renderables from this Context's render tree. If there are children underneath
+     * a renderable, they will also be removed and cleaned up.
+     *
+     * @method remove
+     *
+     * @param {Object} obj renderable object
+     * @return {RenderNode} RenderNode wrapping this object, if not already a RenderNode
+     */
+    Context.prototype.remove = function remove(obj) {
+        return this._node.remove(obj);
     };
 
     /**

--- a/core/View.js
+++ b/core/View.js
@@ -83,6 +83,16 @@ define(function(require, exports, module) {
     View.prototype._add = View.prototype.add;
 
     /**
+     * Remove a child renderable from the view.
+     *
+     * @method remove
+     * @return {RenderNode}
+     */
+    View.prototype.remove = function remove() {
+        return this._node.remove.apply(this._node, arguments);
+    };
+
+    /**
      * Generate a render spec from the contents of this component.
      *
      * @private

--- a/search/BreadthFirstSearch.js
+++ b/search/BreadthFirstSearch.js
@@ -1,0 +1,24 @@
+define(function(require, exports, module) {
+  var BreadthSearch = require('./BreadthSearch');
+
+  /**
+   *  Perform a breadth first search on a rootnode, stopping when the desired
+   *  Modifier, Surface or RenderNode is found
+   *
+   *  @param rootNode {RenderNode} Root renderNode to search from
+   *  @param objectToFind {Surface|Modifier|RenderNode} 
+   *    Surface, modifier, or renderNode to find somewhere in the tree.
+   *
+   *  @method NodeBreadthSearch
+   */
+  function NodeBreadthSearch (rootNode, objectToFind) {
+    function findNode (currentNode) {
+        return currentNode == objectToFind ||
+            currentNode._object == objectToFind ||
+            currentNode._child == objectToFind // renderNode
+    }
+    return BreadthSearch(rootNode, findNode);
+  }
+
+  module.exports = NodeBreadthSearch;
+});

--- a/search/BreadthSearch.js
+++ b/search/BreadthSearch.js
@@ -1,0 +1,50 @@
+define(function(require, exports, module) {
+
+  /**
+   *  Abstract Breadth First Search for Famo.us the render tree. 
+   *  If you pass a function, and it returns a truthy value, the search will stop.
+   *  @param rootNode {RenderNode} node to start the search from
+   *  @param fn {Function} Fn to call when a node is found.
+   *  @returns {RenderNode|undefined} 
+   *    If the fn returns a truthy value, the search stops, and the currentNode is returned
+   *    If that case never occurs, undefined is returned.
+   *
+   *  @method BreadthSearch
+   */
+  function BreadthSearch (rootNode, fn) {
+    var queue = [];
+    var set = {};
+    queue.push(rootNode);
+    set[rootNode._id] = rootNode;
+
+    function enqueueNode (node) {
+        var currId = node._id;
+        if (!set[currId]) { 
+            queue.push(node);
+            set[currId] = node;
+        }
+    }
+
+    var currentNode;
+    while (currentNode = queue.shift()) { 
+        if (fn(currentNode)) { 
+            return currentNode;
+        }
+        if (currentNode._hasMultipleChildren) {
+            var children = currentNode._child;
+            for (var i = 0; i < children.length; i++) {
+                enqueueNode(children[i]);
+            };
+        }
+        else if (currentNode._child) {
+            enqueueNode(currentNode._child);
+        }
+        else if (currentNode._object && currentNode._object._node) {
+            enqueueNode(currentNode._object._node);
+        }
+    }
+    return undefined; // found nothing.
+  }
+
+  module.exports = BreadthSearch;
+});

--- a/search/EntityCleaner.js
+++ b/search/EntityCleaner.js
@@ -1,0 +1,26 @@
+define(function(require, exports, module) {
+  var BreadthSearch = require('./BreadthSearch');
+  var Entity = require('famous/core/Entity');
+
+  /**
+   *  From a single point on the tree, unregister all nested surfaces from Entity
+   *  @param rootNode {RenderNode} Parent node to start the search from
+   *  @method EntityCleaner
+   */
+  function EntityCleaner (rootNode, allocator) {
+    function findNode (currentNode) {
+      if (currentNode._object && 
+          currentNode._object.id !== undefined && 
+          Entity.get(currentNode._object.id) == currentNode._object) { 
+
+            if (allocator && currentNode._object.cleanup) { 
+                currentNode._object.cleanup(allocator)
+            }
+            Entity.unregister(currentNode._object.id);
+      }
+    };
+    return BreadthSearch(rootNode, findNode);
+  }
+
+  module.exports = EntityCleaner;
+});


### PR DESCRIPTION
Solves: https://github.com/Famous/core/issues/7

There are times when developing Famo.us apps that the developer knows they are completely done with content generated in Famo.us. For those times, it is desired to have the ability to remove items from the scene graph, including complete removal from Entity. 

Other than custom event cleanup, this pull request would enable developers to permanently remove items from a Context, View, or RenderNode directly.

example:

``` js
var myView = new View();
var someSurface = new Surface();
myView.add(someSurface);

// at a later point
myView.remove(someSurface) // surface removed from the render tree and unregistered from entity
```

If you have a parent with multiple children, all nested entities are unregistered and removed. All deregistering / entity cleanup happens immediately.

The remove method is tested with Mocha in [this repo.](https://github.com/timjchin/removalTesting)
Currently tested:

```
BFS   
One level   
should find a single level surface   
should find a single level modifier   
shouldn't find a node not included in the tree   

deep level   

should find a nested surface.   
should find a nested modifier.   
should find a surface inside of a view   
should find a surface inside of a view inside of a view   
should find a surface inside of a view inside of a view inside of a view..   

Removal   

should remove a nested surface.   
should unregister a nested surface from Entity.   
should remove a portion of the render tree.   
should remove a portion of the render tree inside of a view.   
should remove a portion of the render tree inside of a view. Multiple surfaces.   
should remove a portion of the render tree inside of a view. Multiple surfaces inside nested Views.   
should unregister the portions of the render tree that were removed.   

Remove From Live Famo.us   

should remove a surface.   
should remove a portion of the render tree.   
should remove a portion of the render tree.   
```

Required Changes
RenderNode is aware of it's parent. This allows faster traversal up the tree, all the way to the Context it is attached to. 
RenderNode has an ID.

This implementation of remove supports Views, Modifiers, Surfaces, or items that have a renderNode as `._node`. As a caveat, components like HeaderFooterLayout would not be supported with complete cleanup. They could gain support if they conform to the View pattern of having one parent renderNode aliased as  `._node`. Similar components could be refactored to support that pattern.
