### PR TITLE
Updated CLA to correct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,4 +143,4 @@ repositories.
 [esr]: http://www.catb.org/esr/
 [taoup]: http://www.catb.org/esr/writings/taoup/
 [modifying-ojects-considered-bad]: http://perfectionkills.com/whats-wrong-with-extending-the-dom/
-[cla]: http://famo.us/cla/individual
+[cla]: http://famo.us/cla


### PR DESCRIPTION
Noticed that this link was incorrect. Updated to the proper path: http://famous/cla
