### PR TITLE
Improved Engine Run Loop using cAF

### DIFF
--- a/core/Engine.js
+++ b/core/Engine.js
@@ -30,14 +30,20 @@ define(function(require, exports, module) {
 
     var Engine = {};
 
+    var timer = window.performance || Date;
+    var requestAnimationFrame = window.requestAnimationFrame;
+    var cancelAnimationFrame = window.cancelAnimationFrame;
+
+    var requestID;
+
     var contexts = [];
     var nextTickQueue = [];
     var deferQueue = [];
 
-    var lastTime = Date.now();
+    var lastTime = timer.now();
     var frameTime;
     var frameTimeLimit;
-    var loopEnabled = true;
+    var loopEnabled = false;
     var eventForwarders = {};
     var eventHandler = new EventHandler();
 
@@ -45,7 +51,6 @@ define(function(require, exports, module) {
         containerType: 'div',
         containerClass: 'famous-container',
         fpsCap: undefined,
-        runLoop: true,
         appMode: true
     };
     var optionsManager = new OptionsManager(options);
@@ -54,19 +59,21 @@ define(function(require, exports, module) {
     var MAX_DEFER_FRAME_TIME = 10;
 
     /**
-     * Inside requestAnimationFrame loop, step() is called, which:
-     *   calculates current FPS (throttling loop if it is over limit set in setFPSCap),
-     *   emits dataless 'prerender' event on start of loop,
-     *   calls in order any one-shot functions registered by nextTick on last loop,
-     *   calls Context.update on all Context objects registered,
-     *   and emits dataless 'postrender' event on end of loop.
+     * This is the main loop of the engine, which will schedule itself to be
+     * called via requestAnimationFrame over and over by default. Within it the
+     * following steps take place sequentially:
+     *   calculate current FPS (throttling loop if it is over limit set in setFPSCap),
+     *   emit dataless 'prerender' event on start of loop,
+     *   call in order any one-shot functions registered by nextTick on last loop,
+     *   call Context.update on all Context objects registered,
+     *   emit dataless 'postrender' event on end of loop.
      *
-     * @static
-     * @private
-     * @method step
+     * @param  {Number} timestamp High-resolution timestamp passed in by rAF.
+     * @param  {Number} quantity Number of frames to loop through. If false,
+     *                           Engine will loop indefinitely.
      */
-    Engine.step = function step() {
-        var currentTime = Date.now();
+    function loop(timestamp, quantity) {
+        var currentTime = timer.now();
 
         // skip frame if we're over our framerate cap
         if (frameTimeLimit && currentTime - lastTime < frameTimeLimit) return;
@@ -83,24 +90,66 @@ define(function(require, exports, module) {
         nextTickQueue.splice(0);
 
         // limit total execution time for deferrable functions
-        while (deferQueue.length && (Date.now() - currentTime) < MAX_DEFER_FRAME_TIME) {
+        while (deferQueue.length && (timer.now() - currentTime) < MAX_DEFER_FRAME_TIME) {
             deferQueue.shift().call(this);
         }
 
         for (i = 0; i < contexts.length; i++) contexts[i].update();
 
         eventHandler.emit('postrender');
+        // Unless step is true, continue processing frames.
+        if (quantity ===  void 0) {
+            // void 0 is fastest safe way to check if value is `undefined`
+            requestID = requestAnimationFrame(loop);
+        } else if (typeof quantity === 'number' && quantity > 0) {
+            quantity--;
+            requestID = requestAnimationFrame(function(timestamp) {
+                loop(timestamp, quantity);
+            });
+        }
+    }
+
+    /**
+     * Enable the Engine step loop.
+     *
+     */
+    Engine.enable = function enable() {
+        if (!loopEnabled) {
+            requestID = requestAnimationFrame(loop);
+            loopEnabled = true;
+        }
     };
 
-    // engage requestAnimationFrame
-    function loop() {
-        if (options.runLoop) {
-            Engine.step();
-            window.requestAnimationFrame(loop);
+    /**
+     * Disable the Engine step loop.
+     *
+     */
+    Engine.disable = function disable() {
+        if (typeof requestID === 'number') {
+            cancelAnimationFrame(requestID);
+            requestID = undefined;
+            loopEnabled = false;
         }
-        else loopEnabled = false;
-    }
-    window.requestAnimationFrame(loop);
+    };
+
+    Engine.enable();
+
+    /**
+     * If step() is called, the Engine is disabled and the frame is advanced
+     * once by default. step() can be called with a quantity to advance the
+     * Engine that many number of frames.
+     *
+     * @static
+     * @public
+     * @method step
+     * @param  {Number} quantity Number of frames to loop through. If false,
+     *                           Engine will loop indefinitely.
+     */
+    Engine.step = function step(quantity) {
+        quantity = quantity || 1;
+        Engine.disable();
+        loop(timer.now(), quantity);
+    };
 
     //
     // Upon main document window resize (unless on an "input" HTML element):
@@ -261,7 +310,6 @@ define(function(require, exports, module) {
      *
      * @param {Object} [options] overrides of default options
      * @param {Number} [options.fpsCap]  maximum fps at which the system should run
-     * @param {boolean} [options.runLoop=true] whether the run loop should continue
      * @param {string} [options.containerType="div"] type of container element.  Defaults to 'div'.
      * @param {string} [options.containerClass="famous-container"] type of container element.  Defaults to 'famous-container'.
      */
@@ -368,11 +416,10 @@ define(function(require, exports, module) {
     optionsManager.on('change', function(data) {
         if (data.id === 'fpsCap') Engine.setFPSCap(data.value);
         else if (data.id === 'runLoop') {
-            // kick off the loop only if it was stopped
-            if (!loopEnabled && data.value) {
-                loopEnabled = true;
-                window.requestAnimationFrame(loop);
-            }
+            /*eslint-disable */
+            console.log('Option `runLoop` is deprecated. Use Engine.enable() instead.');
+            /*eslint-enable */
+            if (data.value) Engine.enable();
         }
     });
 


### PR DESCRIPTION
This commit improves the Engine.js run loop using cancelAnimationFrame.

This is basically a cleaner rewrite of a similar pull request on `famous/core` (deprecated). More info here:
https://github.com/Famous/core/pull/54