### PR TITLE
Implement toggleClass

### DIFF
--- a/core/Surface.js
+++ b/core/Surface.js
@@ -115,7 +115,7 @@ define(function(require, exports, module) {
      * @method toggleClass
      * @param {string} className name of class to toggle
      */
-    Surface.prototype.toggleClass = function removeClass(className) {
+    Surface.prototype.toggleClass = function toggleClass(className) {
         var i = this.classList.indexOf(className);
         if (i >= 0) {
             this.removeClass(className);


### PR DESCRIPTION
This commit implements a toggleClass function. This is the equivalent to jQuery's toggleClass() function.

New:

``` javascript
    /**
     * Toggle CSS-style class from the list of classes on this Surface.
     *   Note this will map directly to the HTML property of the actual
     *   corresponding rendered <div>.
     *
     * @method toggleClass
     * @param {string} className name of class to toggle
     */
    Surface.prototype.toggleClass = function removeClass(className) {
        var i = this.classList.indexOf(className);
        if (i >= 0) {
            this.removeClass(className);
        } else {
            this.addClass(className);
        }
    };
```
