### PR TITLE
Fix TransitionableTransform bug

### DIFF
--- a/transitions/TransitionableTransform.js
+++ b/transitions/TransitionableTransform.js
@@ -23,10 +23,16 @@ define(function(require, exports, module) {
      */
     function TransitionableTransform(transform) {
         this._final = Transform.identity.slice();
-        this.translate = new Transitionable([0, 0, 0]);
-        this.rotate = new Transitionable([0, 0, 0]);
-        this.skew = new Transitionable([0, 0, 0]);
-        this.scale = new Transitionable([1, 1, 1]);
+
+        this._finalTranslate = [0, 0, 0];
+        this._finalRotate = [0, 0, 0];
+        this._finalSkew = [0, 0, 0];
+        this._finalScale = [1, 1, 1];
+
+        this.translate = new Transitionable(this._finalTranslate);
+        this.rotate = new Transitionable(this._finalRotate);
+        this.skew = new Transitionable(this._finalSkew);
+        this.scale = new Transitionable(this._finalScale);
 
         if (transform) this.set(transform);
     }
@@ -37,6 +43,15 @@ define(function(require, exports, module) {
             rotate: this.rotate.get(),
             skew: this.skew.get(),
             scale: this.scale.get()
+        });
+    }
+
+    function _buildFinal() {
+        return Transform.build({
+            translate: this._finalTranslate,
+            rotate: this._finalRotate,
+            skew: this._finalSkew,
+            scale: this._finalScale
         });
     }
 
@@ -52,11 +67,9 @@ define(function(require, exports, module) {
      * @return {TransitionableTransform}
      */
     TransitionableTransform.prototype.setTranslate = function setTranslate(translate, transition, callback) {
+        this._finalTranslate = translate;
+        this._final = _buildFinal.call(this);
         this.translate.set(translate, transition, callback);
-        this._final = this._final.slice();
-        this._final[12] = translate[0];
-        this._final[13] = translate[1];
-        if (translate[2] !== undefined) this._final[14] = translate[2];
         return this;
     };
 
@@ -72,11 +85,9 @@ define(function(require, exports, module) {
      * @return {TransitionableTransform}
      */
     TransitionableTransform.prototype.setScale = function setScale(scale, transition, callback) {
+        this._finalScale = scale;
+        this._final = _buildFinal.call(this);
         this.scale.set(scale, transition, callback);
-        this._final = this._final.slice();
-        this._final[0] = scale[0];
-        this._final[5] = scale[1];
-        if (scale[2] !== undefined) this._final[10] = scale[2];
         return this;
     };
 
@@ -92,14 +103,9 @@ define(function(require, exports, module) {
      * @return {TransitionableTransform}
      */
     TransitionableTransform.prototype.setRotate = function setRotate(eulerAngles, transition, callback) {
+        this._finalRotate = eulerAngles;
+        this._final = _buildFinal.call(this);
         this.rotate.set(eulerAngles, transition, callback);
-        this._final = _build.call(this);
-        this._final = Transform.build({
-            translate: this.translate.get(),
-            rotate: eulerAngles,
-            scale: this.scale.get(),
-            skew: this.skew.get()
-        });
         return this;
     };
 
@@ -115,13 +121,9 @@ define(function(require, exports, module) {
      * @return {TransitionableTransform}
      */
     TransitionableTransform.prototype.setSkew = function setSkew(skewAngles, transition, callback) {
+        this._finalSkew = skewAngles;
+        this._final = _buildFinal.call(this);
         this.skew.set(skewAngles, transition, callback);
-        this._final = Transform.build({
-            translate: this.translate.get(),
-            rotate: this.rotate.get(),
-            scale: this.scale.get(),
-            skew: skewAngles
-        });
         return this;
     };
 
@@ -138,8 +140,13 @@ define(function(require, exports, module) {
      * @return {TransitionableTransform}
      */
     TransitionableTransform.prototype.set = function set(transform, transition, callback) {
-        this._final = transform;
         var components = Transform.interpret(transform);
+
+        this._finalTranslate = components.translate;
+        this._finalRotate = components.rotate;
+        this._finalSkew = components.skew;
+        this._finalScale = components.scale;
+        this._final = transform;
 
         var _callback = callback ? Utility.after(4, callback) : null;
         this.translate.set(components.translate, transition, _callback);


### PR DESCRIPTION
Considering the following example:

``` javascript
    var Engine = require('famous/core/Engine');
    var Surface = require('famous/core/Surface');
    var TransitionableTransform = require('famous/transitions/TransitionableTransform');
    var Modifier = require('famous/core/Modifier');

    var surface = new Surface({
        size: [100, 100],
        properties: {
            background: 'red'
        }
    });

    var tt = new TransitionableTransform();

    var modifier = new Modifier({
        align: [0.5, 0.5],
        origin: [0.5, 0.5],
        transform: tt
    });

    Engine.createContext().add(modifier).add(surface);

    tt.setTranslate([100, 100, 0], {
        duration: 1000
    });

    tt.setRotate([0, 0, Math.PI/2], {
        duration: 1000
    });
```

This resets the surface to its original position after finishing the rotation, producing a undesirable flash effect.
This commit fixes this issue. While recalculating the matrix might be expensive, at least it works. It seems to me that the _final state is being calculated incorrectly.
