### PR TITLE
Reset origin dirty flag on setup

### DIFF
--- a/core/Surface.js
+++ b/core/Surface.js
@@ -241,6 +241,7 @@ define(function(require, exports, module) {
         this._classesDirty = true;
         this._sizeDirty = true;
         this._contentDirty = true;
+        this._originDirty = true;
         this._transformDirty = true;
     };
 


### PR DESCRIPTION
The origin is not flagged dirty at setup, using for example RenderController or Lightbox makes this bugged.
