### PR TITLE
Added ClickFix

### DIFF
--- a/inputs/ClickFix.js
+++ b/inputs/ClickFix.js
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Owner: peter@appmachine.com
+ * @license MPL 2.0
+ * @copyright Famous Industries, Inc. 2014
+ */
+
+define(function(require, exports, module) {
+    /**
+     * ClickFix is an shim that stops 'click' event when there is movement between mousedown
+     * and mouseup is more then the clickTolerance. This enables to let user scroll with mouse
+     * through scrollbar without triggering click.
+     */
+    var clickTolerance = 5;
+    var potentialClick = null;
+
+    window.addEventListener('mousedown', function (event) {
+        potentialClick = {
+            position: [event.clientX, event.clientY],
+            target: event.target
+        };
+
+        event.target.addEventListener('mousemove', _handleMove, true);
+        event.target.addEventListener('mouseup', _handleEnd, true);
+    }, true);
+
+    function _handleMove(event) {
+        if (potentialClick) {
+            if (Math.abs(potentialClick.position[0] - event.clientX) > clickTolerance || Math.abs(potentialClick.position[1] - event.clientY) > clickTolerance)
+                potentialClick.cancel = true;
+        }
+    }
+
+    function _handleEnd(event) {
+        event.target.removeEventListener('mousemove', _handleMove);
+        event.target.removeEventListener('mouseup', _handleEnd);
+    }
+
+    window.addEventListener('click', function(event) {
+        if (potentialClick && potentialClick.cancel && potentialClick.target === event.target) event.stopPropagation();
+        potentialClick = null;
+    }, true);
+});

--- a/inputs/ClickFix.js
+++ b/inputs/ClickFix.js
@@ -16,7 +16,7 @@ define(function(require, exports, module) {
     var clickTolerance = 5;
     var potentialClick = null;
 
-    window.addEventListener('mousedown', function (event) {
+    window.addEventListener('mousedown', function(event) {
         potentialClick = {
             position: [event.clientX, event.clientY],
             target: event.target

--- a/inputs/ClickFix.js
+++ b/inputs/ClickFix.js
@@ -22,8 +22,8 @@ define(function(require, exports, module) {
             target: event.target
         };
 
-        event.target.addEventListener('mousemove', _handleMove, true);
-        event.target.addEventListener('mouseup', _handleEnd, true);
+        window.addEventListener('mousemove', _handleMove, true);
+        window.addEventListener('mouseup', _handleEnd, true);
     }, true);
 
     function _handleMove(event) {
@@ -34,8 +34,8 @@ define(function(require, exports, module) {
     }
 
     function _handleEnd(event) {
-        event.target.removeEventListener('mousemove', _handleMove);
-        event.target.removeEventListener('mouseup', _handleEnd);
+        window.removeEventListener('mousemove', _handleMove);
+        window.removeEventListener('mouseup', _handleEnd);
     }
 
     window.addEventListener('click', function(event) {


### PR DESCRIPTION
Prevents users from triggering clicks when using mouse sync on scrollview, normally you get a click when you swipe the scrollview. So using Scrollview for menu for example is impossible using MouseSync.

Maybe this should be merged in MouseSync, just like conversation going on this.