### PR TITLE
Add support for input syncs without direction defined

### DIFF
--- a/views/Scrollview.js
+++ b/views/Scrollview.js
@@ -139,8 +139,14 @@ define(function(require, exports, module) {
     }
 
     function _handleMove(event) {
-        var velocity = -event.velocity;
-        var delta = -event.delta;
+        var velocity, delta;
+        if (typeof event.delta === 'number') {
+            velocity = -event.velocity;
+            delta = -event.delta;
+        } else {
+            velocity = -event.velocity[this.options.direction];
+            delta = -event.delta[this.options.direction];
+        }
 
         if (this._onEdge && event.slip) {
             if ((velocity < 0 && this._onEdge < 0) || (velocity > 0 && this._onEdge > 0)) {
@@ -166,7 +172,7 @@ define(function(require, exports, module) {
             _detachAgents.call(this);
             if (this._onEdge) _setSpring.call(this, this._edgeSpringPosition, SpringStates.EDGE);
             _attachAgents.call(this);
-            var velocity = -event.velocity;
+            var velocity = typeof event.velocity === 'number' ? -event.velocity : -event.velocity[this.options.direction];
             var speedLimit = this.options.speedLimit;
             if (event.slip) speedLimit *= this.options.edgeGrip;
             if (velocity < -speedLimit) velocity = -speedLimit;

--- a/views/Scrollview.js
+++ b/views/Scrollview.js
@@ -139,7 +139,8 @@ define(function(require, exports, module) {
     }
 
     function _handleMove(event) {
-        var velocity, delta;
+        var velocity
+        var delta;
         if (typeof event.delta === 'number') {
             velocity = -event.velocity;
             delta = -event.delta;


### PR DESCRIPTION
When you create a GenericSync / MouseSync with direction undefined the velocity / delta variable on the event is an array and makes current code crash. This checkin allows for support for this.