### PR TITLE
Fix linter to fail on eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run lint -s",
     "lint-eslint": "eslint core/ events/ inputs/ math/ modifiers/ physics/ surfaces/ transitions/ utilities/ views/ widgets/",
     "lint-jscs": "jscs core/ events/ inputs/ math/ modifiers/ physics/ surfaces/ transitions/ utilities/ views/ widgets/",
-    "lint": "npm run lint-eslint; npm run lint-jscs"
+    "lint": "npm run lint-eslint && npm run lint-jscs"
   },
   "author": "famous",
   "license": "MPL v2.0",


### PR DESCRIPTION
Originally we were not explicitly running one linter after another, and if eslint failed it would not trigger a failure on travis.
