### PR TITLE
Prevent double initialization of engine

### DIFF
--- a/core/Engine.js
+++ b/core/Engine.js
@@ -130,7 +130,7 @@ define(function(require, exports, module) {
             return;
 
         initialized = true;
-        
+
         // prevent scrolling via browser
         window.addEventListener('touchmove', function(event) {
             event.preventDefault();


### PR DESCRIPTION
Prevent double initializing of engine upon creating second context, else you get double window binding.
