### PR TITLE
Fix for loading Famo.us in HEAD element of DOM

### DIFF
--- a/core/ElementOutput.js
+++ b/core/ElementOutput.js
@@ -12,8 +12,14 @@ define(function(require, exports, module) {
     var EventHandler = require('./EventHandler');
     var Transform = require('./Transform');
 
-    var usePrefix = document.body.style.webkitTransform !== undefined;
     var devicePixelRatio = window.devicePixelRatio || 1;
+
+    var usePrefix = true;
+    if (!document.body) {
+        document.addEventListener('DOMContentLoaded', function() {
+            usePrefix = document.body.style.webkitTransform !== undefined;
+        });
+    } else usePrefix = document.body.style.webkitTransform !== undefined;
 
     /**
      * A base class for viewable content and event


### PR DESCRIPTION
When you load Famo.us in the HEAD element of the DOM there is a small change that document.body evaluates to null. This would cause in a 'TypeError: 'null' is not an object (evaluating 'document.body.style')' currently.
