### PR TITLE
sizeDirty flag removed

### DIFF
--- a/core/ElementOutput.js
+++ b/core/ElementOutput.js
@@ -251,7 +251,6 @@ define(function(require, exports, module) {
         }
 
         if (_xyNotEquals(this._origin, origin)) this._originDirty = true;
-        if (_xyNotEquals(this._size, size)) this._sizeDirty = true;
         if (Transform.notEquals(this._matrix, matrix)) this._transformDirty = true;
 
         if (this._invisible) {


### PR DESCRIPTION
https://github.com/Famous/famous/pull/186

https://github.com/contra/famous/blob/0fe835dd391142f188435d41979ae0b2205fe9d7/core/ElementOutput.js#L254

The context's size, referenced as `size`, is very often not equal to `this._size`. When this is the case, `this._sizeDirty` is always true, and leads to exponential sizing. Removing the `_xyNotEquals` check solves the issue. 

@michaelobriena 
@TheAlphaNerd 
