### PR TITLE
change DEFAULT_OPTION direction to Y

### DIFF
--- a/views/ScrollContainer.js
+++ b/views/ScrollContainer.js
@@ -45,7 +45,7 @@ define(function(require, exports, module) {
         container: {
             properties: {overflow : 'hidden'}
         },
-        scrollview: {direction: Utility.Direction.X}
+        scrollview: {direction: Utility.Direction.Y}
     };
 
     /**


### PR DESCRIPTION
All files that refer Scroll, like Scroller.js and ScrollView, uses Y as DEFAULT_OPTIONS direction, just ScrollContent don't. When i used scrollContainer without subscribe the option direction to Y, it didn't work, it rendered all items on horizontal, and the scroll didn't work too.
