### PR TITLE
When body is null

### DIFF
--- a/core/ElementOutput.js
+++ b/core/ElementOutput.js
@@ -12,7 +12,7 @@ define(function(require, exports, module) {
     var EventHandler = require('./EventHandler');
     var Transform = require('./Transform');
 
-    var usePrefix = document.body.style.webkitTransform !== undefined;
+    var usePrefix = document.body ? document.body.style.webkitTransform !== undefined : false;
     var devicePixelRatio = window.devicePixelRatio || 1;
 
     /**


### PR DESCRIPTION
I'm using famono to integrate famous with meteor, this code var usePrefix = document.body.style.webkitTransform !== undefined always happen before body render, cause of the templates in meteor. For this always the body is null in this point and throw an exception
