### PR TITLE
Automatic Transition Registeries

### DIFF
--- a/transitions/RegisterEasing.js
+++ b/transitions/RegisterEasing.js
@@ -1,0 +1,50 @@
+define(function(require, exports, module) {
+    var Easing = require('./Easing');
+    var TweenTransition = require('./TweenTransition');
+
+    /**
+     * Helper function to register easing curves globally in an application.
+     * To use this, all you must do is require this in.
+     *
+     * @example
+     *  // Anywhere in your application, typically in app.js
+     *  var RegisterEasing = require('registries/Easing');
+     *
+     *  // Allows transitions as follows:
+     *  myModifier.setTransform(Transform.identity, {
+     *    curve: 'outExpo', // as a string, not direct reference to Easing.outExpo.
+     *    duration: 500
+     *  });
+     *
+     * @class RegisterEasing
+     * @protected
+     *
+     */
+    function getKeys(obj) {
+        var keys = [];
+        for (var key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                keys.push(key);
+            }
+        }
+        return keys;
+    }
+
+    function getAvailableTransitionCurves() {
+        var keys = getKeys(Easing);
+        var curves = {};
+        for (var i = 0; i < keys.length; i++) {
+            curves[keys[i]] = Easing[keys[i]];
+        }
+        return curves;
+    }
+
+    function registerKeys () {
+        var curves = getAvailableTransitionCurves();
+        for (var key in curves) {
+            TweenTransition.registerCurve(key, curves[key]);
+        }
+    }
+
+    registerKeys();
+});

--- a/transitions/RegisterPhysics.js
+++ b/transitions/RegisterPhysics.js
@@ -1,0 +1,10 @@
+define(function(require, exports, module) {
+    var Transitionable   = require('./Transitionable');
+    var SpringTransition = require('./SpringTransition');
+    var SnapTransition   = require('./SnapTransition');
+    var WallTransition   = require('./WallTransition');
+
+    Transitionable.registerMethod('spring', SpringTransition);
+    Transitionable.registerMethod('snap', SnapTransition);
+    Transitionable.registerMethod('wall', WallTransition);
+});


### PR DESCRIPTION
These two files register all of the easing curves and physics transitions to TweenTransition and Transitionable respectively. This enables developers to define transition definitions in straight JSON, and not have direct references to Easing functions. 

``` js
// once in the application
require('famous/transitions/RegisterEasing');
require('famous/transitions/RegisterPhysics');

// Tween Transition 
myModifier.setTransform(Transform.identity, { 
  curve: 'outExpo',
  duration: 500 
})

// Physics
myModifier.setTransform(Transform.identity, { 
  method: 'spring',
  period: 500,
  dampingRatio: 0.25
})
```

It's a lot easier to use, instead of requiring in Easing every time a transition is desired. 

``` js
var Easing = require('famous/transitions/Easing');
myModifier.setTransform(Transform.identity, { 
  curve: Easing.outExpo,
  duration: 500 
})
```

@michaelobriena
