### PR TITLE
Fixed typos in function documentation and errors

### DIFF
--- a/views/RenderController.js
+++ b/views/RenderController.js
@@ -122,7 +122,7 @@ define(function(require, exports, module) {
 
     /**
      * outTransformFrom sets the accessor for the state of the transform used in transitioning out renderables.
-     * @method show
+     * @method outTransformFrom
      * @param {Function|Transitionable} transform  A function that returns a transform from outside closure, or a
      * a transitionable that manages a full transform (a sixteen value array).
      * @chainable
@@ -130,14 +130,14 @@ define(function(require, exports, module) {
     RenderController.prototype.outTransformFrom = function outTransformFrom(transform) {
         if (transform instanceof Function) this.outTransformMap = transform;
         else if (transform && transform.get) this.outTransformMap = transform.get.bind(transform);
-        else throw new Error('inTransformFrom takes only function or getter object');
+        else throw new Error('outTransformFrom takes only function or getter object');
         //TODO: tween transition
         return this;
     };
 
     /**
      * outOpacityFrom sets the accessor for the state of the opacity used in transitioning out renderables.
-     * @method inOpacityFrom
+     * @method outOpacityFrom
      * @param {Function|Transitionable} opacity  A function that returns an opacity from outside closure, or a
      * a transitionable that manages opacity (a number between zero and one).
      * @chainable
@@ -145,14 +145,14 @@ define(function(require, exports, module) {
     RenderController.prototype.outOpacityFrom = function outOpacityFrom(opacity) {
         if (opacity instanceof Function) this.outOpacityMap = opacity;
         else if (opacity && opacity.get) this.outOpacityMap = opacity.get.bind(opacity);
-        else throw new Error('inOpacityFrom takes only function or getter object');
+        else throw new Error('outOpacityFrom takes only function or getter object');
         //TODO: tween opacity
         return this;
     };
 
     /**
      * outOriginFrom sets the accessor for the state of the origin used in transitioning out renderables.
-     * @method inOriginFrom
+     * @method outOriginFrom
      * @param {Function|Transitionable} origin A function that returns an origin from outside closure, or a
      * a transitionable that manages origin (a two value array of numbers between zero and one).
      * @chainable
@@ -160,7 +160,7 @@ define(function(require, exports, module) {
     RenderController.prototype.outOriginFrom = function outOriginFrom(origin) {
         if (origin instanceof Function) this.outOriginMap = origin;
         else if (origin && origin.get) this.outOriginMap = origin.get.bind(origin);
-        else throw new Error('inOriginFrom takes only function or getter object');
+        else throw new Error('outOriginFrom takes only function or getter object');
         //TODO: tween origin
         return this;
     };


### PR DESCRIPTION
Function descriptions/documentation and corresponding errors were not always referencing the correct function. This is now fixed so that it is clearer to the user.
