### PR TITLE
[FIX] Attach entities to window object

### DIFF
--- a/core/Entity.js
+++ b/core/Entity.js
@@ -6,6 +6,7 @@
  * @license MPL 2.0
  * @copyright Famous Industries, Inc. 2014
  */
+/*global global */
 
 define(function(require, exports, module) {
     /**
@@ -16,8 +17,9 @@ define(function(require, exports, module) {
      * @static
      * @class Entity
      */
-
-    var entities = [];
+    // Shim for global and window so you don't break node.js support
+    var bossMode = global || window;
+    var entities = bossMode.famousEntities = bossMode.famousEntities || [];
 
     /**
      * Get entity from global index.


### PR DESCRIPTION
Currently Entity is a singleton that lives in closure.  This abstraction breaks when you introduce multiple contexts that may have their own instantiations of Entity.  This is currently experienced when trying to use browserify and node_modules to require in things such as widgets or ui components.  Unlike bower which has a flat tree of dependencies, npm creates a tree structure, and you end up with modules referencing their own copies of famous. 

One way to solve this without changing the framework would be to require widgets to have famous injected into them.  My main concern with the above suggested approach is that it invovles loading the entire framework in order to inject, unless a widget uses IOC to request specific parts of the frame work.

Both of those suggestions are complicated though, and put the implementation details into the hands of the users.

This suggested patch attaches the entites array to the window object, opening up a small portion of the renderloop to the public, but in doing so removes the need to manage the abstractions mentioned above.

Truthfully I view this as a temporary solution to allow us not to block developers while we can begin a discussion about whether or not the Entity Abstraction should be removed altogether.  I do realize that there are performance concerns, and that it is being used for certain types of garbage collection.  As such it will be necessary to run some perf tests to decide if the performance benefits outweigh the practical usage.
