### PR TITLE
fix vendor prefix checks, closes #218, #208, and #162

### DIFF
--- a/core/Context.js
+++ b/core/Context.js
@@ -14,7 +14,7 @@ define(function(require, exports, module) {
     var Transform = require('./Transform');
     var Transitionable = require('famous/transitions/Transitionable');
 
-    var usePrefix = ('webkitPerspective' in document.documentElement);
+    var usePrefix = !('perspective' in document.documentElement.style);
     var _originZeroZero = [0, 0];
 
     function _getElementSize(element) {

--- a/core/ElementOutput.js
+++ b/core/ElementOutput.js
@@ -12,7 +12,7 @@ define(function(require, exports, module) {
     var EventHandler = require('./EventHandler');
     var Transform = require('./Transform');
 
-    var usePrefix = ('webkitTransform' in document.documentElement);
+    var usePrefix = !('transform' in document.documentElement.style);
     var devicePixelRatio = window.devicePixelRatio || 1;
 
     /**


### PR DESCRIPTION
Stuff fixed:
- ElementOutput required that document.body exists, which makes famous not work when added in head or if there is no body.
- Context was adding two style declarations (unprefixed and prefixed) even when they weren't needed. This will detect the need for vendor prefixes to reduce the total number of DOM hits on perspective change
- Context was including an invalid value on non-prefixed perspective style declarations (`1000` instead of `1000px`

This will solve all of that
