### PR TITLE
Feature sequential layout cleanup

### DIFF
--- a/views/SequentialLayout.js
+++ b/views/SequentialLayout.js
@@ -105,7 +105,7 @@ define(function(require, exports, module) {
      */
     SequentialLayout.prototype.render = function render() {
         var length             = 0;
-        var secondaryDirection = (this.options.direction + 1) ^ 1;
+        var secondaryDirection = this.options.direction ^ 1;
         var currentNode        = this._items;
         var item               = null;
         var itemSize           = [];


### PR DESCRIPTION
Clean up of logic in SequentialLayout.  Gets rid of bug where if a Surface has no size then it grows exponentially. Removes girth, itemSpacing, and default size.  Allows for updated getSize on parent change by computing size per frame.
