### PR TITLE
Fix for illegal return in FastClick.js (alternative #1)

### DIFF
--- a/inputs/FastClick.js
+++ b/inputs/FastClick.js
@@ -14,53 +14,54 @@ define(function(require, exports, module) {
      *   threshold to the 'click' event.
      *   This is used to speed up clicks on some browsers.
      */
-    if (!window.CustomEvent) return;
-    var clickThreshold = 300;
-    var clickWindow = 500;
-    var potentialClicks = {};
-    var recentlyDispatched = {};
-    var _now = Date.now;
+    if (window.CustomEvent) {;
+      var clickThreshold = 300;
+      var clickWindow = 500;
+      var potentialClicks = {};
+      var recentlyDispatched = {};
+      var _now = Date.now;
 
-    window.addEventListener('touchstart', function(event) {
-        var timestamp = _now();
-        for (var i = 0; i < event.changedTouches.length; i++) {
-            var touch = event.changedTouches[i];
-            potentialClicks[touch.identifier] = timestamp;
-        }
-    });
+      window.addEventListener('touchstart', function(event) {
+          var timestamp = _now();
+          for (var i = 0; i < event.changedTouches.length; i++) {
+              var touch = event.changedTouches[i];
+              potentialClicks[touch.identifier] = timestamp;
+          }
+      });
 
-    window.addEventListener('touchmove', function(event) {
-        for (var i = 0; i < event.changedTouches.length; i++) {
-            var touch = event.changedTouches[i];
-            delete potentialClicks[touch.identifier];
-        }
-    });
+      window.addEventListener('touchmove', function(event) {
+          for (var i = 0; i < event.changedTouches.length; i++) {
+              var touch = event.changedTouches[i];
+              delete potentialClicks[touch.identifier];
+          }
+      });
 
-    window.addEventListener('touchend', function(event) {
-        var currTime = _now();
-        for (var i = 0; i < event.changedTouches.length; i++) {
-            var touch = event.changedTouches[i];
-            var startTime = potentialClicks[touch.identifier];
-            if (startTime && currTime - startTime < clickThreshold) {
-                var clickEvt = new window.CustomEvent('click', {
-                    'bubbles': true,
-                    'detail': touch
-                });
-                recentlyDispatched[currTime] = event;
-                event.target.dispatchEvent(clickEvt);
-            }
-            delete potentialClicks[touch.identifier];
-        }
-    });
+      window.addEventListener('touchend', function(event) {
+          var currTime = _now();
+          for (var i = 0; i < event.changedTouches.length; i++) {
+              var touch = event.changedTouches[i];
+              var startTime = potentialClicks[touch.identifier];
+              if (startTime && currTime - startTime < clickThreshold) {
+                  var clickEvt = new window.CustomEvent('click', {
+                      'bubbles': true,
+                      'detail': touch
+                  });
+                  recentlyDispatched[currTime] = event;
+                  event.target.dispatchEvent(clickEvt);
+              }
+              delete potentialClicks[touch.identifier];
+          }
+      });
 
-    window.addEventListener('click', function(event) {
-        var currTime = _now();
-        for (var i in recentlyDispatched) {
-            var previousEvent = recentlyDispatched[i];
-            if (currTime - i < clickWindow) {
-                if (event instanceof window.MouseEvent && event.target === previousEvent.target) event.stopPropagation();
-            }
-            else delete recentlyDispatched[i];
-        }
-    }, true);
+      window.addEventListener('click', function(event) {
+          var currTime = _now();
+          for (var i in recentlyDispatched) {
+              var previousEvent = recentlyDispatched[i];
+              if (currTime - i < clickWindow) {
+                  if (event instanceof window.MouseEvent && event.target === previousEvent.target) event.stopPropagation();
+              }
+              else delete recentlyDispatched[i];
+          }
+      }, true);
+    }
 });


### PR DESCRIPTION
When using `browserify` with `deamdify`, FastClick can break any `browserify` transform that uses `esprima` because `FastClick` essentially has an illegal `return`. i.e. without the AMD wrapper, there is a return statement at the Program level scope. This is an illegal return because ECMA-262 does not allow you to return at the global/Program level scope. Changing the conditional on the first line to check for the truthiness of window.customEvent fixes this. This is an alternative fix to #242. Either works. I think this one is more elegant. 
