### PR TITLE
TransitionableTransform: Fix halt()

### DIFF
--- a/transitions/TransitionableTransform.js
+++ b/transitions/TransitionableTransform.js
@@ -212,11 +212,16 @@ define(function(require, exports, module) {
      * @method halt
      */
     TransitionableTransform.prototype.halt = function halt() {
-        this._final = this.get();
         this.translate.halt();
         this.rotate.halt();
         this.skew.halt();
         this.scale.halt();
+
+        this._final = this.get();
+        this._finalTranslate = this.translate.get();
+        this._finalRotate = this.rotate.get();
+        this._finalSkew = this.skew.get();
+        this._finalScale = this.scale.get();
     };
 
     module.exports = TransitionableTransform;


### PR DESCRIPTION
Each final state needs to be set to the current state after the transition has been halted. Otherwise the _final\* states do not represent the actual final states, but the final states of the previous (unfinished) transformation. This results into unexpected behavior when doing a single transformation (e.g. rotation) on a halted TransitionableTransform that didn't update its final states, since the _buildFinal uses the _final\* of each Transformation (which hasn't been updated).
