### PR TITLE
Remove unnecessary event in OptionsManager

### DIFF
--- a/core/OptionsManager.js
+++ b/core/OptionsManager.js
@@ -78,7 +78,6 @@ define(function(require, exports, module) {
                 if ((k in myState) && (data[k] && data[k].constructor === Object) && (myState[k] && myState[k].constructor === Object)) {
                     if (!myState.hasOwnProperty(k)) myState[k] = Object.create(myState[k]);
                     this.key(k).patch(data[k]);
-                    if (this.eventOutput) this.eventOutput.emit('change', {id: k, value: this.key(k).value()});
                 }
                 else this.set(k, data[k]);
             }


### PR DESCRIPTION
We should only be emitting a change event on a primitive data type change. The event emitted in patch is redundant and could reduce performance.
