### PR TITLE
[Fix] Wrap Fast Click in Closure

### DIFF
--- a/inputs/FastClick.js
+++ b/inputs/FastClick.js
@@ -14,53 +14,55 @@ define(function(require, exports, module) {
      *   threshold to the 'click' event.
      *   This is used to speed up clicks on some browsers.
      */
-    if (!window.CustomEvent) return;
-    var clickThreshold = 300;
-    var clickWindow = 500;
-    var potentialClicks = {};
-    var recentlyDispatched = {};
-    var _now = Date.now;
+    (function() {
+      if (!window.CustomEvent) return;
+      var clickThreshold = 300;
+      var clickWindow = 500;
+      var potentialClicks = {};
+      var recentlyDispatched = {};
+      var _now = Date.now;
 
-    window.addEventListener('touchstart', function(event) {
-        var timestamp = _now();
-        for (var i = 0; i < event.changedTouches.length; i++) {
-            var touch = event.changedTouches[i];
-            potentialClicks[touch.identifier] = timestamp;
-        }
-    });
+      window.addEventListener('touchstart', function(event) {
+          var timestamp = _now();
+          for (var i = 0; i < event.changedTouches.length; i++) {
+              var touch = event.changedTouches[i];
+              potentialClicks[touch.identifier] = timestamp;
+          }
+      });
 
-    window.addEventListener('touchmove', function(event) {
-        for (var i = 0; i < event.changedTouches.length; i++) {
-            var touch = event.changedTouches[i];
-            delete potentialClicks[touch.identifier];
-        }
-    });
+      window.addEventListener('touchmove', function(event) {
+          for (var i = 0; i < event.changedTouches.length; i++) {
+              var touch = event.changedTouches[i];
+              delete potentialClicks[touch.identifier];
+          }
+      });
 
-    window.addEventListener('touchend', function(event) {
-        var currTime = _now();
-        for (var i = 0; i < event.changedTouches.length; i++) {
-            var touch = event.changedTouches[i];
-            var startTime = potentialClicks[touch.identifier];
-            if (startTime && currTime - startTime < clickThreshold) {
-                var clickEvt = new window.CustomEvent('click', {
-                    'bubbles': true,
-                    'detail': touch
-                });
-                recentlyDispatched[currTime] = event;
-                event.target.dispatchEvent(clickEvt);
-            }
-            delete potentialClicks[touch.identifier];
-        }
-    });
+      window.addEventListener('touchend', function(event) {
+          var currTime = _now();
+          for (var i = 0; i < event.changedTouches.length; i++) {
+              var touch = event.changedTouches[i];
+              var startTime = potentialClicks[touch.identifier];
+              if (startTime && currTime - startTime < clickThreshold) {
+                  var clickEvt = new window.CustomEvent('click', {
+                      'bubbles': true,
+                      'detail': touch
+                  });
+                  recentlyDispatched[currTime] = event;
+                  event.target.dispatchEvent(clickEvt);
+              }
+              delete potentialClicks[touch.identifier];
+          }
+      });
 
-    window.addEventListener('click', function(event) {
-        var currTime = _now();
-        for (var i in recentlyDispatched) {
-            var previousEvent = recentlyDispatched[i];
-            if (currTime - i < clickWindow) {
-                if (event instanceof window.MouseEvent && event.target === previousEvent.target) event.stopPropagation();
-            }
-            else delete recentlyDispatched[i];
-        }
-    }, true);
+      window.addEventListener('click', function(event) {
+          var currTime = _now();
+          for (var i in recentlyDispatched) {
+              var previousEvent = recentlyDispatched[i];
+              if (currTime - i < clickWindow) {
+                  if (event instanceof window.MouseEvent && event.target === previousEvent.target) event.stopPropagation();
+              }
+              else delete recentlyDispatched[i];
+          }
+      }, true);
+    })();
 });


### PR DESCRIPTION
Currently fast click calls return if `!window.CustomEvent`.  This caused no problems when we were only releasing using AMD, as this return was wrapped in closure, but it unfortunately breaks everything when the framework is run in Common.

This fix wraps all the code inside of fast click in a self executing function, making sure that the return doesn't make everything throw up.
