### PR TITLE
Smarter FastClick

### DIFF
--- a/inputs/FastClick.js
+++ b/inputs/FastClick.js
@@ -18,6 +18,7 @@ define(function(require, exports, module) {
       if (!window.CustomEvent) return;
       var clickThreshold = 300;
       var clickWindow = 500;
+      var positionWindow = 35;
       var potentialClicks = {};
       var recentlyDispatched = {};
       var _now = Date.now;
@@ -59,7 +60,14 @@ define(function(require, exports, module) {
           for (var i in recentlyDispatched) {
               var previousEvent = recentlyDispatched[i];
               if (currTime - i < clickWindow) {
-                  if (event instanceof window.MouseEvent && event.target === previousEvent.target) event.stopPropagation();
+                  if (event instanceof window.MouseEvent) {
+                      for (var j = 0; j < previousEvent.changedTouches.length; j++) {
+                          var touch = previousEvent.changedTouches[j];
+                          if (Math.abs(event.clientX - touch.clientX) < positionWindow &&
+                              Math.abs(event.clientY - touch.clientY) < positionWindow
+                          ) event.stopPropagation();
+                      }
+                  }
               }
               else delete recentlyDispatched[i];
           }


### PR DESCRIPTION
The current FastClick implementation matches events based on the event target. This doesn't work for my app because at the point of time the click event finally fires an animation has already played thus the click **event hits a different target** and it won't get canceled properly. I propose doing the matching based on the position. That's more reliable in the typical animation heavy famo.us app.

For those who have concerns that this isn't strict enough anymore, here's the deal: The worst thing that can happen is that the event for a legit click gets canceled that happened within the first 500ms after a touch in a only 70px wide box around it. This half second isn't even enough time to grab the mouse properly :)
