### PR TITLE
Remove out of date firefox optimizations

### DIFF
--- a/core/ElementOutput.js
+++ b/core/ElementOutput.js
@@ -158,9 +158,6 @@ define(function(require, exports, module) {
      * @return {string} matrix3d CSS style representation of the transform
      */
     function _formatCSSTransform(m) {
-        m[12] = Math.round(m[12] * devicePixelRatio) / devicePixelRatio;
-        m[13] = Math.round(m[13] * devicePixelRatio) / devicePixelRatio;
-
         var result = 'matrix3d(';
         for (var i = 0; i < 15; i++) {
             result += (m[i] < 0.000001 && m[i] > -0.000001) ? '0,' : m[i] + ',';


### PR DESCRIPTION
I was speaking to @marklu about firefox performance the other day, and
he suggested that I remove these lines, because they were no longer
relevant.

According to him they are left over from an older firefox, and were
scheduled to be removed.

I have signed the CLA.
