### PR TITLE
Add guard to TouchTracker to avoid unexpected behavior from multitouch gestures

### DIFF
--- a/inputs/TouchSync.js
+++ b/inputs/TouchSync.js
@@ -24,6 +24,7 @@ define(function(require, exports, module) {
      * @param [options.direction] {Number}   read from a particular axis
      * @param [options.rails] {Boolean}      read from axis with greatest differential
      * @param [options.scale] {Number}       constant factor to scale velocity output
+     * @param [options.touchLimit] {Number}  touchLimit upper bound for emitting events based on number of touches
      */
     function TouchSync(options) {
         this.options =  Object.create(TouchSync.DEFAULT_OPTIONS);
@@ -31,7 +32,9 @@ define(function(require, exports, module) {
         if (options) this.setOptions(options);
 
         this._eventOutput = new EventHandler();
-        this._touchTracker = new TouchTracker();
+        this._touchTracker = new TouchTracker({
+            touchLimit: this.options.touchLimit
+        });
 
         EventHandler.setOutputHandler(this, this._eventOutput);
         EventHandler.setInputHandler(this, this._touchTracker);
@@ -56,7 +59,8 @@ define(function(require, exports, module) {
     TouchSync.DEFAULT_OPTIONS = {
         direction: undefined,
         rails: false,
-        scale: 1
+        scale: 1,
+        touchLimit: 1
     };
 
     TouchSync.DIRECTION_X = 0;

--- a/inputs/TouchTracker.js
+++ b/inputs/TouchTracker.js
@@ -24,7 +24,7 @@ define(function(require, exports, module) {
     }
 
     function _handleStart(event) {
-        if (event.touches.length !== 1) return;
+        if (event.touches.length > this.touchLimit) return;
         this.isTouched = true;
 
         for (var i = 0; i < event.changedTouches.length; i++) {
@@ -36,7 +36,7 @@ define(function(require, exports, module) {
     }
 
     function _handleMove(event) {
-        if (event.touches.length !== 1) return;
+        if (event.touches.length > this.touchLimit) return;
 
         for (var i = 0; i < event.changedTouches.length; i++) {
             var touch = event.changedTouches[i];
@@ -51,7 +51,6 @@ define(function(require, exports, module) {
 
     function _handleEnd(event) {
         if (!this.isTouched) return;
-        this.isTouched = false;
 
         for (var i = 0; i < event.changedTouches.length; i++) {
             var touch = event.changedTouches[i];
@@ -62,6 +61,8 @@ define(function(require, exports, module) {
                 delete this.touchHistory[touch.identifier];
             }
         }
+
+        this.isTouched = false;
     }
 
     function _handleUnpipe() {
@@ -84,10 +85,14 @@ define(function(require, exports, module) {
      *
      * @class TouchTracker
      * @constructor
-     * @param {Boolean} selective if false, save state for each touch.
+     * @param {Object} options default options overrides
+     * @param [options.selective] {Boolean} selective if false, saves state for each touch
+     * @param [options.touchLimit] {Number} touchLimit upper bound for emitting events based on number of touches
      */
-    function TouchTracker(selective) {
-        this.selective = selective;
+    function TouchTracker(options) {
+        this.selective = options.selective;
+        this.touchLimit = options.touchLimit || 1;
+
         this.touchHistory = {};
 
         this.eventInput = new EventHandler();


### PR DESCRIPTION
Currently, multitouch (e.g., two finger pinch) gestures trigger 'start', 'update' and 'end' events on the TouchSync. This places a large burden on the developer to parse event data in order to achieve expected behavior. This problem is exacerbated if the developer desires to have both a TouchSync and PinchSync attached to a surface. Take the example of a developer wanting to 'drag' an surface using the TouchSync and to scale it using the PinchSync. Every time the user pinches, both those touches are going to be piped into the TouchSync causing the surface to move in erratic ways. Every developer trying to implement this common case would need to parse the data.identifier in order to adjust for only one touch input. A simpler solution is to only have the TouchSync map to one finger gestures (and if a developer wants to move an item with a two finger gestures they can do so by using the data.center attribute passed through the PinchSync.)

This PR updates TouchTracker to:
1.) Only emit 'start'/'update' events if there is a single touch
2.) Only emit 'end' events if 'start' was previously triggered by a single touch.
