### PR TITLE
[bug] Utility.clone nested array handling

### DIFF
--- a/utilities/Utility.js
+++ b/utilities/Utility.js
@@ -93,7 +93,7 @@ define(function(require, exports, module) {
     Utility.clone = function clone(b) {
         var a;
         if (typeof b === 'object') {
-            a = {};
+            a = (b instanceof Array) ? [] : {};
             for (var key in b) {
                 if (typeof b[key] === 'object' && b[key] !== null) {
                     if (b[key] instanceof Array) {


### PR DESCRIPTION
If you current pass in an object that has nested arrays such as:

``` js
var cloned = Utility.clone({ 
   a: [ 0, 1, [ 2, 3]]
});
// Utility.clone would return:
cloned === { 
    a: [0, 1, { 0: 2, 1: 3}]
}
```

This checks the type of b before setting it to an object or array, allowing the expected output.

@TheAlphaNerd
