### PR TITLE
Remove remaining currTarget references

### DIFF
--- a/surfaces/CanvasSurface.js
+++ b/surfaces/CanvasSurface.js
@@ -94,7 +94,7 @@ define(function(require, exports, module) {
      */
     CanvasSurface.prototype.getContext = function getContext(contextId) {
         this._contextId = contextId;
-        return this._currTarget ? this._currTarget.getContext(contextId) : this._backBuffer.getContext(contextId);
+        return this._currentTarget ? this._currentTarget.getContext(contextId) : this._backBuffer.getContext(contextId);
     };
 
     /**
@@ -107,9 +107,9 @@ define(function(require, exports, module) {
     CanvasSurface.prototype.setSize = function setSize(size, canvasSize) {
         Surface.prototype.setSize.apply(this, arguments);
         if (canvasSize) this._canvasSize = [canvasSize[0], canvasSize[1]];
-        if (this._currTarget) {
-            this._currTarget.width = this._canvasSize[0];
-            this._currTarget.height = this._canvasSize[1];
+        if (this._currentTarget) {
+            this._currentTarget.width = this._canvasSize[0];
+            this._currentTarget.height = this._canvasSize[1];
         }
     };
 

--- a/surfaces/InputSurface.js
+++ b/surfaces/InputSurface.js
@@ -32,7 +32,7 @@ define(function(require, exports, module) {
 
         this.on('click', this.focus.bind(this));
         window.addEventListener('click', function(event) {
-            if (event.target !== this._currTarget) this.blur();
+            if (event.target !== this._currentTarget) this.blur();
         }.bind(this));
     }
     InputSurface.prototype = Object.create(Surface.prototype);
@@ -61,7 +61,7 @@ define(function(require, exports, module) {
      * @return {InputSurface} this, allowing method chaining.
      */
     InputSurface.prototype.focus = function focus() {
-        if (this._currTarget) this._currTarget.focus();
+        if (this._currentTarget) this._currentTarget.focus();
         return this;
     };
 
@@ -72,7 +72,7 @@ define(function(require, exports, module) {
      * @return {InputSurface} this, allowing method chaining.
      */
     InputSurface.prototype.blur = function blur() {
-        if (this._currTarget) this._currTarget.blur();
+        if (this._currentTarget) this._currentTarget.blur();
         return this;
     };
 
@@ -111,8 +111,8 @@ define(function(require, exports, module) {
      * @return {string} value of element
      */
     InputSurface.prototype.getValue = function getValue() {
-        if (this._currTarget) {
-            return this._currTarget.value;
+        if (this._currentTarget) {
+            return this._currentTarget.value;
         }
         else {
             return this._value;

--- a/surfaces/TextareaSurface.js
+++ b/surfaces/TextareaSurface.js
@@ -62,7 +62,7 @@ define(function(require, exports, module) {
      * @return {TextareaSurface} this, allowing method chaining.
      */
     TextareaSurface.prototype.focus = function focus() {
-        if (this._currTarget) this._currTarget.focus();
+        if (this._currentTarget) this._currentTarget.focus();
         return this;
     };
 
@@ -73,7 +73,7 @@ define(function(require, exports, module) {
      * @return {TextareaSurface} this, allowing method chaining.
      */
     TextareaSurface.prototype.blur = function blur() {
-        if (this._currTarget) this._currTarget.blur();
+        if (this._currentTarget) this._currentTarget.blur();
         return this;
     };
 
@@ -98,8 +98,8 @@ define(function(require, exports, module) {
      * @return {string} value of element
      */
     TextareaSurface.prototype.getValue = function getValue() {
-        if (this._currTarget) {
-            return this._currTarget.value;
+        if (this._currentTarget) {
+            return this._currentTarget.value;
         }
         else {
             return this._value;


### PR DESCRIPTION
It was renamed to _currentTarget a while ago, but all these surfaces are incorrect.

This stuff should actually be fairly easily testable, have you guys considered Zuul?
