### PR TITLE
Version match to branch until release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "famous",
-  "version": "0.2.2",
+  "version": "0.3.0-alpha",
   "description": "Famo.us is a JavaScript framework for everyone who wants to build beautiful experiences on any device.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was pulling down the branch and it kept showing 0.2.2

Helpful when using the branch from github rather than the npm package
