### PR TITLE
Relative path all the things

### DIFF
--- a/core/Context.js
+++ b/core/Context.js
@@ -12,7 +12,7 @@ define(function(require, exports, module) {
     var EventHandler = require('./EventHandler');
     var ElementAllocator = require('./ElementAllocator');
     var Transform = require('./Transform');
-    var Transitionable = require('famous/transitions/Transitionable');
+    var Transitionable = require('../transitions/Transitionable');
 
     var _zeroZero = [0, 0];
     var usePrefix = !('perspective' in document.documentElement.style);

--- a/core/Modifier.js
+++ b/core/Modifier.js
@@ -11,8 +11,8 @@ define(function(require, exports, module) {
     var Transform = require('./Transform');
 
     /* TODO: remove these dependencies when deprecation complete */
-    var Transitionable = require('famous/transitions/Transitionable');
-    var TransitionableTransform = require('famous/transitions/TransitionableTransform');
+    var Transitionable = require('../transitions/Transitionable');
+    var TransitionableTransform = require('../transitions/TransitionableTransform');
 
     /**
      *

--- a/core/View.js
+++ b/core/View.js
@@ -11,7 +11,7 @@ define(function(require, exports, module) {
     var EventHandler = require('./EventHandler');
     var OptionsManager = require('./OptionsManager');
     var RenderNode = require('./RenderNode');
-    var Utility = require('famous/utilities/Utility');
+    var Utility = require('../utilities/Utility');
 
     /**
      * Useful for quickly creating elements within applications

--- a/events/EventArbiter.js
+++ b/events/EventArbiter.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var EventHandler = require('famous/core/EventHandler');
+    var EventHandler = require('../core/EventHandler');
 
     /**
      * A switch which wraps several event destinations and

--- a/events/EventFilter.js
+++ b/events/EventFilter.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var EventHandler = require('famous/core/EventHandler');
+    var EventHandler = require('../core/EventHandler');
 
     /**
      * EventFilter regulates the broadcasting of events based on

--- a/events/EventMapper.js
+++ b/events/EventMapper.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var EventHandler = require('famous/core/EventHandler');
+    var EventHandler = require('../core/EventHandler');
 
     /**
      * EventMapper routes events to various event destinations

--- a/inputs/Accumulator.js
+++ b/inputs/Accumulator.js
@@ -1,6 +1,6 @@
 define(function(require, exports, module) {
-    var EventHandler = require('famous/core/EventHandler');
-    var Transitionable = require('famous/transitions/Transitionable');
+    var EventHandler = require('../core/EventHandler');
+    var Transitionable = require('../transitions/Transitionable');
 
     /**
      * Accumulates differentials of event sources that emit a `delta`

--- a/inputs/MouseSync.js
+++ b/inputs/MouseSync.js
@@ -21,8 +21,8 @@ define(function(require, exports, module) {
      * @constructor
      *
      * @example
-     *   var Surface = require('famous/core/Surface');
-     *   var MouseSync = require('famous/inputs/MouseSync');
+     *   var Surface = require('../core/Surface');
+     *   var MouseSync = require('../inputs/MouseSync');
      *
      *   var surface = new Surface({ size: [100, 100] });
      *   var mouseSync = new MouseSync();

--- a/inputs/TouchSync.js
+++ b/inputs/TouchSync.js
@@ -21,8 +21,8 @@ define(function(require, exports, module) {
      * @constructor
      *
      * @example
-     *   var Surface = require('famous/core/Surface');
-     *   var TouchSync = require('famous/inputs/TouchSync');
+     *   var Surface = require('../core/Surface');
+     *   var TouchSync = require('../inputs/TouchSync');
      *
      *   var surface = new Surface({ size: [100, 100] });
      *   var touchSync = new TouchSync();

--- a/modifiers/Draggable.js
+++ b/modifiers/Draggable.js
@@ -8,14 +8,14 @@
  */
 
 define(function(require, exports, module) {
-    var Transform = require('famous/core/Transform');
-    var Transitionable = require('famous/transitions/Transitionable');
-    var EventHandler = require('famous/core/EventHandler');
-    var Utilities = require('famous/math/Utilities');
+    var Transform = require('../core/Transform');
+    var Transitionable = require('../transitions/Transitionable');
+    var EventHandler = require('../core/EventHandler');
+    var Utilities = require('../math/Utilities');
 
-    var GenericSync = require('famous/inputs/GenericSync');
-    var MouseSync = require('famous/inputs/MouseSync');
-    var TouchSync = require('famous/inputs/TouchSync');
+    var GenericSync = require('../inputs/GenericSync');
+    var MouseSync = require('../inputs/MouseSync');
+    var TouchSync = require('../inputs/TouchSync');
     GenericSync.register({'mouse': MouseSync, 'touch': TouchSync});
 
     /**

--- a/modifiers/Fader.js
+++ b/modifiers/Fader.js
@@ -1,6 +1,6 @@
 define(function(require, exports, module) {
-    var Transitionable = require('famous/transitions/Transitionable');
-    var OptionsManager = require('famous/core/OptionsManager');
+    var Transitionable = require('../transitions/Transitionable');
+    var OptionsManager = require('../core/OptionsManager');
 
     /**
      * Modifier that allows you to fade the opacity of affected renderables in and out.

--- a/modifiers/StateModifier.js
+++ b/modifiers/StateModifier.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var Modifier = require('famous/core/Modifier');
-    var Transform = require('famous/core/Transform');
-    var Transitionable = require('famous/transitions/Transitionable');
-    var TransitionableTransform = require('famous/transitions/TransitionableTransform');
+    var Modifier = require('../core/Modifier');
+    var Transform = require('../core/Transform');
+    var Transitionable = require('../transitions/Transitionable');
+    var TransitionableTransform = require('../transitions/TransitionableTransform');
 
     /**
      *  A collection of visual changes to be

--- a/physics/PhysicsEngine.js
+++ b/physics/PhysicsEngine.js
@@ -6,7 +6,7 @@
  * @copyright Famous Industries, Inc. 2014
  */
 define(function(require, exports, module) {
-    var EventHandler = require('famous/core/EventHandler');
+    var EventHandler = require('../core/EventHandler');
 
     /**
      * The Physics Engine is responsible for mediating bodies with their

--- a/physics/bodies/Body.js
+++ b/physics/bodies/Body.js
@@ -9,10 +9,10 @@
 
 define(function(require, exports, module) {
     var Particle = require('./Particle');
-    var Transform = require('famous/core/Transform');
-    var Vector = require('famous/math/Vector');
-    var Quaternion = require('famous/math/Quaternion');
-    var Matrix = require('famous/math/Matrix');
+    var Transform = require('../../core/Transform');
+    var Vector = require('../../math/Vector');
+    var Quaternion = require('../../math/Quaternion');
+    var Matrix = require('../../math/Matrix');
     var Integrator = require('../integrators/SymplecticEuler');
 
     /**

--- a/physics/bodies/Circle.js
+++ b/physics/bodies/Circle.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Body = require('./Body');
-    var Matrix = require('famous/math/Matrix');
+    var Matrix = require('../../math/Matrix');
 
     /**
      * Implements a circle, or spherical, geometry for a Body with

--- a/physics/bodies/Particle.js
+++ b/physics/bodies/Particle.js
@@ -8,9 +8,9 @@
  */
 
 define(function(require, exports, module) {
-    var Vector = require('famous/math/Vector');
-    var Transform = require('famous/core/Transform');
-    var EventHandler = require('famous/core/EventHandler');
+    var Vector = require('../../math/Vector');
+    var Transform = require('../../core/Transform');
+    var EventHandler = require('../../core/EventHandler');
     var Integrator = require('../integrators/SymplecticEuler');
 
     /**

--- a/physics/bodies/Rectangle.js
+++ b/physics/bodies/Rectangle.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Body = require('./Body');
-    var Matrix = require('famous/math/Matrix');
+    var Matrix = require('../../math/Matrix');
 
     /**
      * Implements a rectangular geometry for an Body with

--- a/physics/constraints/Collision.js
+++ b/physics/constraints/Collision.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Constraint = require('./Constraint');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  Allows for two circular bodies to collide and bounce off each other.

--- a/physics/constraints/Constraint.js
+++ b/physics/constraints/Constraint.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var EventHandler = require('famous/core/EventHandler');
+    var EventHandler = require('../../core/EventHandler');
 
     /**
      *  Allows for two circular bodies to collide and bounce off each other.

--- a/physics/constraints/Curve.js
+++ b/physics/constraints/Curve.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Constraint = require('./Constraint');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  A constraint that keeps a physics body on a given implicit curve

--- a/physics/constraints/Distance.js
+++ b/physics/constraints/Distance.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Constraint = require('./Constraint');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  A constraint that keeps a physics body a given distance away from a given

--- a/physics/constraints/Snap.js
+++ b/physics/constraints/Snap.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Constraint = require('./Constraint');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  A spring constraint is like a spring force, except that it is always

--- a/physics/constraints/Surface.js
+++ b/physics/constraints/Surface.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Constraint = require('./Constraint');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  A constraint that keeps a physics body on a given implicit surface

--- a/physics/constraints/Wall.js
+++ b/physics/constraints/Wall.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Constraint = require('./Constraint');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  A wall describes an infinite two-dimensional plane that physics bodies

--- a/physics/constraints/Walls.js
+++ b/physics/constraints/Walls.js
@@ -10,7 +10,7 @@
 define(function(require, exports, module) {
     var Constraint = require('./Constraint');
     var Wall = require('./Wall');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  Walls combines one or more Wall primitives and exposes a simple API to

--- a/physics/forces/Force.js
+++ b/physics/forces/Force.js
@@ -8,8 +8,8 @@
  */
 
 define(function(require, exports, module) {
-    var Vector = require('famous/math/Vector');
-    var EventHandler = require('famous/core/EventHandler');
+    var Vector = require('../../math/Vector');
+    var EventHandler = require('../../core/EventHandler');
 
     /**
      * Force base class.

--- a/physics/forces/Repulsion.js
+++ b/physics/forces/Repulsion.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Force = require('./Force');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  Repulsion is a force that repels (attracts) bodies away (towards)

--- a/physics/forces/RotationalSpring.js
+++ b/physics/forces/RotationalSpring.js
@@ -11,7 +11,7 @@
 define(function(require, exports, module) {
     var Force = require('./Force');
     var Spring = require('./Spring');
-    var Quaternion = require('famous/math/Quaternion');
+    var Quaternion = require('../../math/Quaternion');
 
     /**
      *  A force that rotates a physics body back to target Euler angles.

--- a/physics/forces/Spring.js
+++ b/physics/forces/Spring.js
@@ -11,7 +11,7 @@
 
 define(function(require, exports, module) {
     var Force = require('./Force');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  A force that moves a physics body to a location with a spring motion.

--- a/physics/forces/VectorField.js
+++ b/physics/forces/VectorField.js
@@ -9,7 +9,7 @@
 
 define(function(require, exports, module) {
     var Force = require('./Force');
-    var Vector = require('famous/math/Vector');
+    var Vector = require('../../math/Vector');
 
     /**
      *  A force that moves a physics body to a location with a spring motion.

--- a/surfaces/CanvasSurface.js
+++ b/surfaces/CanvasSurface.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var Surface = require('famous/core/Surface');
+    var Surface = require('../core/Surface');
 
     /**
      * A surface containing an HTML5 Canvas element.

--- a/surfaces/ContainerSurface.js
+++ b/surfaces/ContainerSurface.js
@@ -9,8 +9,8 @@
  */
 
 define(function(require, exports, module) {
-    var Surface = require('famous/core/Surface');
-    var Context = require('famous/core/Context');
+    var Surface = require('../core/Surface');
+    var Context = require('../core/Context');
 
     /**
      * ContainerSurface is an object designed to contain surfaces and

--- a/surfaces/ImageSurface.js
+++ b/surfaces/ImageSurface.js
@@ -9,7 +9,7 @@
  */
 
 define(function(require, exports, module) {
-    var Surface = require('famous/core/Surface');
+    var Surface = require('../core/Surface');
 
     /**
      * A surface containing image content.

--- a/surfaces/InputSurface.js
+++ b/surfaces/InputSurface.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var Surface = require('famous/core/Surface');
+    var Surface = require('../core/Surface');
 
     /**
      * A Famo.us surface in the form of an HTML input element.

--- a/surfaces/TextareaSurface.js
+++ b/surfaces/TextareaSurface.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var Surface = require('famous/core/Surface');
+    var Surface = require('../core/Surface');
 
     /**
      * A Famo.us surface in the form of an HTML textarea element.

--- a/surfaces/VideoSurface.js
+++ b/surfaces/VideoSurface.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var Surface = require('famous/core/Surface');
+    var Surface = require('../core/Surface');
 
     /**
      * Creates a famous surface containing video content. Currently adding

--- a/transitions/MultipleTransition.js
+++ b/transitions/MultipleTransition.js
@@ -8,7 +8,7 @@
  */
 
 define(function(require, exports, module) {
-    var Utility = require('famous/utilities/Utility');
+    var Utility = require('../utilities/Utility');
 
     /**
      * Transition meta-method to support transitioning multiple

--- a/transitions/SnapTransition.js
+++ b/transitions/SnapTransition.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var PE = require('famous/physics/PhysicsEngine');
-    var Particle = require('famous/physics/bodies/Particle');
-    var Spring = require('famous/physics/constraints/Snap');
-    var Vector = require('famous/math/Vector');
+    var PE = require('../physics/PhysicsEngine');
+    var Particle = require('../physics/bodies/Particle');
+    var Spring = require('../physics/constraints/Snap');
+    var Vector = require('../math/Vector');
 
     /**
      * SnapTransition is a method of transitioning between two values (numbers,

--- a/transitions/SpringTransition.js
+++ b/transitions/SpringTransition.js
@@ -10,10 +10,10 @@
 /*global console*/
 
 define(function(require, exports, module) {
-    var PE = require('famous/physics/PhysicsEngine');
-    var Particle = require('famous/physics/bodies/Particle');
-    var Spring = require('famous/physics/forces/Spring');
-    var Vector = require('famous/math/Vector');
+    var PE = require('../physics/PhysicsEngine');
+    var Particle = require('../physics/bodies/Particle');
+    var Spring = require('../physics/forces/Spring');
+    var Vector = require('../math/Vector');
 
     /**
      * SpringTransition is a method of transitioning between two values (numbers,

--- a/transitions/TransitionableTransform.js
+++ b/transitions/TransitionableTransform.js
@@ -9,8 +9,8 @@
 
 define(function(require, exports, module) {
     var Transitionable = require('./Transitionable');
-    var Transform = require('famous/core/Transform');
-    var Utility = require('famous/utilities/Utility');
+    var Transform = require('../core/Transform');
+    var Utility = require('../utilities/Utility');
 
     /**
      * A class for transitioning the state of a Transform by transitioning

--- a/transitions/WallTransition.js
+++ b/transitions/WallTransition.js
@@ -8,11 +8,11 @@
  */
 
 define(function(require, exports, module) {
-    var PE = require('famous/physics/PhysicsEngine');
-    var Particle = require('famous/physics/bodies/Particle');
-    var Spring = require('famous/physics/forces/Spring');
-    var Wall = require('famous/physics/constraints/Wall');
-    var Vector = require('famous/math/Vector');
+    var PE = require('../physics/PhysicsEngine');
+    var Particle = require('../physics/bodies/Particle');
+    var Spring = require('../physics/forces/Spring');
+    var Wall = require('../physics/constraints/Wall');
+    var Vector = require('../math/Vector');
 
     /**
      * WallTransition is a method of transitioning between two values (numbers,

--- a/utilities/Timer.js
+++ b/utilities/Timer.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
      * @class Timer
      * @constructor
      */
-    var FamousEngine = require('famous/core/Engine');
+    var FamousEngine = require('../core/Engine');
 
     var _event  = 'prerender';
 

--- a/views/ContextualView.js
+++ b/views/ContextualView.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var Entity = require('famous/core/Entity');
-    var Transform = require('famous/core/Transform');
-    var EventHandler = require('famous/core/EventHandler');
-    var OptionsManager = require('famous/core/OptionsManager');
+    var Entity = require('../core/Entity');
+    var Transform = require('../core/Transform');
+    var EventHandler = require('../core/EventHandler');
+    var OptionsManager = require('../core/OptionsManager');
 
     /**
      * ContextualView is an interface for creating views that need to

--- a/views/Deck.js
+++ b/views/Deck.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var Transform = require('famous/core/Transform');
-    var OptionsManager = require('famous/core/OptionsManager');
-    var Transitionable = require('famous/transitions/Transitionable');
-    var Utility = require('famous/utilities/Utility');
+    var Transform = require('../core/Transform');
+    var OptionsManager = require('../core/OptionsManager');
+    var Transitionable = require('../transitions/Transitionable');
+    var Utility = require('../utilities/Utility');
     var SequentialLayout = require('./SequentialLayout');
 
     /**

--- a/views/DrawerLayout.js
+++ b/views/DrawerLayout.js
@@ -8,11 +8,11 @@
  */
 
 define(function(require, exports, module) {
-    var RenderNode = require('famous/core/RenderNode');
-    var Transform = require('famous/core/Transform');
-    var OptionsManager = require('famous/core/OptionsManager');
-    var Transitionable = require('famous/transitions/Transitionable');
-    var EventHandler = require('famous/core/EventHandler');
+    var RenderNode = require('../core/RenderNode');
+    var Transform = require('../core/Transform');
+    var OptionsManager = require('../core/OptionsManager');
+    var Transitionable = require('../transitions/Transitionable');
+    var EventHandler = require('../core/EventHandler');
 
     /**
      * A layout which will arrange two renderables: a featured content, and a

--- a/views/EdgeSwapper.js
+++ b/views/EdgeSwapper.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var CachedMap = require('famous/transitions/CachedMap');
-    var Entity = require('famous/core/Entity');
-    var EventHandler = require('famous/core/EventHandler');
-    var Transform = require('famous/core/Transform');
+    var CachedMap = require('../transitions/CachedMap');
+    var Entity = require('../core/Entity');
+    var EventHandler = require('../core/EventHandler');
+    var Transform = require('../core/Transform');
     var RenderController = require('./RenderController');
 
     /**

--- a/views/FlexibleLayout.js
+++ b/views/FlexibleLayout.js
@@ -8,11 +8,11 @@
  */
 
 define(function(require, exports, module) {
-    var Entity = require('famous/core/Entity');
-    var Transform = require('famous/core/Transform');
-    var OptionsManager = require('famous/core/OptionsManager');
-    var EventHandler = require('famous/core/EventHandler');
-    var Transitionable = require('famous/transitions/Transitionable');
+    var Entity = require('../core/Entity');
+    var Transform = require('../core/Transform');
+    var OptionsManager = require('../core/OptionsManager');
+    var EventHandler = require('../core/EventHandler');
+    var Transitionable = require('../transitions/Transitionable');
 
     /**
      * A layout which divides a context into sections based on a proportion

--- a/views/Flipper.js
+++ b/views/Flipper.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var Transform = require('famous/core/Transform');
-    var Transitionable = require('famous/transitions/Transitionable');
-    var RenderNode = require('famous/core/RenderNode');
-    var OptionsManager = require('famous/core/OptionsManager');
+    var Transform = require('../core/Transform');
+    var Transitionable = require('../transitions/Transitionable');
+    var RenderNode = require('../core/RenderNode');
+    var OptionsManager = require('../core/OptionsManager');
 
     /**
      * Allows you to link two renderables as front and back sides that can be

--- a/views/GridLayout.js
+++ b/views/GridLayout.js
@@ -8,15 +8,15 @@
  */
 
 define(function(require, exports, module) {
-    var Entity = require('famous/core/Entity');
-    var RenderNode = require('famous/core/RenderNode');
-    var Transform = require('famous/core/Transform');
-    var ViewSequence = require('famous/core/ViewSequence');
-    var EventHandler = require('famous/core/EventHandler');
-    var Modifier = require('famous/core/Modifier');
-    var OptionsManager = require('famous/core/OptionsManager');
-    var Transitionable = require('famous/transitions/Transitionable');
-    var TransitionableTransform = require('famous/transitions/TransitionableTransform');
+    var Entity = require('../core/Entity');
+    var RenderNode = require('../core/RenderNode');
+    var Transform = require('../core/Transform');
+    var ViewSequence = require('../core/ViewSequence');
+    var EventHandler = require('../core/EventHandler');
+    var Modifier = require('../core/Modifier');
+    var OptionsManager = require('../core/OptionsManager');
+    var Transitionable = require('../transitions/Transitionable');
+    var TransitionableTransform = require('../transitions/TransitionableTransform');
 
     /**
      * A layout which divides a context into several evenly-sized grid cells.

--- a/views/HeaderFooterLayout.js
+++ b/views/HeaderFooterLayout.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var Entity = require('famous/core/Entity');
-    var RenderNode = require('famous/core/RenderNode');
-    var Transform = require('famous/core/Transform');
-    var OptionsManager = require('famous/core/OptionsManager');
+    var Entity = require('../core/Entity');
+    var RenderNode = require('../core/RenderNode');
+    var Transform = require('../core/Transform');
+    var OptionsManager = require('../core/OptionsManager');
 
     /**
      * A layout which will arrange three renderables into a header and footer area of defined size,

--- a/views/Lightbox.js
+++ b/views/Lightbox.js
@@ -1,11 +1,11 @@
 define(function(require, exports, module) {
-    var Transform = require('famous/core/Transform');
-    var Modifier = require('famous/core/Modifier');
-    var RenderNode = require('famous/core/RenderNode');
-    var Utility = require('famous/utilities/Utility');
-    var OptionsManager = require('famous/core/OptionsManager');
-    var Transitionable = require('famous/transitions/Transitionable');
-    var TransitionableTransform = require('famous/transitions/TransitionableTransform');
+    var Transform = require('../core/Transform');
+    var Modifier = require('../core/Modifier');
+    var RenderNode = require('../core/RenderNode');
+    var Utility = require('../utilities/Utility');
+    var OptionsManager = require('../core/OptionsManager');
+    var Transitionable = require('../transitions/Transitionable');
+    var TransitionableTransform = require('../transitions/TransitionableTransform');
 
     /**
      * Lightbox, using transitions, shows and hides different renderables. Lightbox can essentially be

--- a/views/RenderController.js
+++ b/views/RenderController.js
@@ -8,11 +8,11 @@
  */
 
 define(function(require, exports, module) {
-    var Modifier = require('famous/core/Modifier');
-    var RenderNode = require('famous/core/RenderNode');
-    var Transform = require('famous/core/Transform');
-    var Transitionable = require('famous/transitions/Transitionable');
-    var View = require('famous/core/View');
+    var Modifier = require('../core/Modifier');
+    var RenderNode = require('../core/RenderNode');
+    var Transform = require('../core/Transform');
+    var Transitionable = require('../transitions/Transitionable');
+    var View = require('../core/View');
 
     /**
      * A dynamic view that can show or hide different renerables with transitions.

--- a/views/ScrollContainer.js
+++ b/views/ScrollContainer.js
@@ -8,11 +8,11 @@
  */
 
 define(function(require, exports, module) {
-    var ContainerSurface = require('famous/surfaces/ContainerSurface');
-    var EventHandler = require('famous/core/EventHandler');
+    var ContainerSurface = require('../surfaces/ContainerSurface');
+    var EventHandler = require('../core/EventHandler');
     var Scrollview = require('./Scrollview');
-    var Utility = require('famous/utilities/Utility');
-    var OptionsManager = require('famous/core/OptionsManager');
+    var Utility = require('../utilities/Utility');
+    var OptionsManager = require('../core/OptionsManager');
 
     /**
      * A Container surface with a scrollview automatically added. The convenience of ScrollContainer lies in

--- a/views/Scroller.js
+++ b/views/Scroller.js
@@ -1,11 +1,11 @@
 define(function(require, exports, module) {
-    var Entity = require('famous/core/Entity');
-    var Group = require('famous/core/Group');
-    var OptionsManager = require('famous/core/OptionsManager');
-    var Transform = require('famous/core/Transform');
-    var Utility = require('famous/utilities/Utility');
-    var ViewSequence = require('famous/core/ViewSequence');
-    var EventHandler = require('famous/core/EventHandler');
+    var Entity = require('../core/Entity');
+    var Group = require('../core/Group');
+    var OptionsManager = require('../core/OptionsManager');
+    var Transform = require('../core/Transform');
+    var Utility = require('../utilities/Utility');
+    var ViewSequence = require('../core/ViewSequence');
+    var EventHandler = require('../core/EventHandler');
 
     /**
      * Scroller lays out a collection of renderables, and will browse through them based on

--- a/views/Scrollview.js
+++ b/views/Scrollview.js
@@ -8,20 +8,20 @@
  */
 
 define(function(require, exports, module) {
-    var PhysicsEngine = require('famous/physics/PhysicsEngine');
-    var Particle = require('famous/physics/bodies/Particle');
-    var Drag = require('famous/physics/forces/Drag');
-    var Spring = require('famous/physics/forces/Spring');
+    var PhysicsEngine = require('../physics/PhysicsEngine');
+    var Particle = require('../physics/bodies/Particle');
+    var Drag = require('../physics/forces/Drag');
+    var Spring = require('../physics/forces/Spring');
 
-    var EventHandler = require('famous/core/EventHandler');
-    var OptionsManager = require('famous/core/OptionsManager');
-    var ViewSequence = require('famous/core/ViewSequence');
-    var Scroller = require('famous/views/Scroller');
-    var Utility = require('famous/utilities/Utility');
+    var EventHandler = require('../core/EventHandler');
+    var OptionsManager = require('../core/OptionsManager');
+    var ViewSequence = require('../core/ViewSequence');
+    var Scroller = require('../views/Scroller');
+    var Utility = require('../utilities/Utility');
 
-    var GenericSync = require('famous/inputs/GenericSync');
-    var ScrollSync = require('famous/inputs/ScrollSync');
-    var TouchSync = require('famous/inputs/TouchSync');
+    var GenericSync = require('../inputs/GenericSync');
+    var ScrollSync = require('../inputs/ScrollSync');
+    var TouchSync = require('../inputs/TouchSync');
     GenericSync.register({scroll : ScrollSync, touch : TouchSync});
 
     /** @const */

--- a/views/SequentialLayout.js
+++ b/views/SequentialLayout.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var OptionsManager = require('famous/core/OptionsManager');
-    var Transform = require('famous/core/Transform');
-    var ViewSequence = require('famous/core/ViewSequence');
-    var Utility = require('famous/utilities/Utility');
+    var OptionsManager = require('../core/OptionsManager');
+    var Transform = require('../core/Transform');
+    var ViewSequence = require('../core/ViewSequence');
+    var Utility = require('../utilities/Utility');
 
     /**
      * SequentialLayout will lay out a collection of renderables sequentially in the specified direction.

--- a/widgets/NavigationBar.js
+++ b/widgets/NavigationBar.js
@@ -8,10 +8,10 @@
  */
 
 define(function(require, exports, module) {
-    var Scene = require('famous/core/Scene');
-    var Surface = require('famous/core/Surface');
-    var Transform = require('famous/core/Transform');
-    var View = require('famous/core/View');
+    var Scene = require('../core/Scene');
+    var Surface = require('../core/Surface');
+    var Transform = require('../core/Transform');
+    var View = require('../core/View');
 
     /**
      * A view for displaying the title of the current page

--- a/widgets/Slider.js
+++ b/widgets/Slider.js
@@ -8,16 +8,16 @@
  */
 
 define(function(require, exports, module) {
-    var Surface = require('famous/core/Surface');
-    var CanvasSurface = require('famous/surfaces/CanvasSurface');
-    var Transform = require('famous/core/Transform');
-    var EventHandler = require('famous/core/EventHandler');
-    var Utilities = require('famous/math/Utilities');
-    var OptionsManager = require('famous/core/OptionsManager');
+    var Surface = require('../core/Surface');
+    var CanvasSurface = require('../surfaces/CanvasSurface');
+    var Transform = require('../core/Transform');
+    var EventHandler = require('../core/EventHandler');
+    var Utilities = require('../math/Utilities');
+    var OptionsManager = require('../core/OptionsManager');
 
-    var MouseSync = require('famous/inputs/MouseSync');
-    var TouchSync = require('famous/inputs/TouchSync');
-    var GenericSync = require('famous/inputs/GenericSync');
+    var MouseSync = require('../inputs/MouseSync');
+    var TouchSync = require('../inputs/TouchSync');
+    var GenericSync = require('../inputs/GenericSync');
 
     GenericSync.register({
         mouse : MouseSync,

--- a/widgets/TabBar.js
+++ b/widgets/TabBar.js
@@ -8,9 +8,9 @@
  */
 
 define(function(require, exports, module) {
-    var Utility = require('famous/utilities/Utility');
-    var View = require('famous/core/View');
-    var GridLayout = require('famous/views/GridLayout');
+    var Utility = require('../utilities/Utility');
+    var View = require('../core/View');
+    var GridLayout = require('../views/GridLayout');
     var ToggleButton = require('./ToggleButton');
 
     /**

--- a/widgets/ToggleButton.js
+++ b/widgets/ToggleButton.js
@@ -8,9 +8,9 @@
  */
 
 define(function(require, exports, module) {
-    var Surface = require('famous/core/Surface');
-    var EventHandler = require('famous/core/EventHandler');
-    var RenderController = require('famous/views/RenderController');
+    var Surface = require('../core/Surface');
+    var EventHandler = require('../core/EventHandler');
+    var RenderController = require('../views/RenderController');
 
     /**
      * A view for transitioning between two surfaces based


### PR DESCRIPTION
Moving forward we are planning to have famous all in a single src directory.  This is moving even further from the initial design of having git submodules.  As such maintaining absolute path's to modules is not only not necessary, but is actually incorrect and breaking certain tools.

This pull request goes through and replaces all references to famous with the appropriate relative path.
