### PR TITLE
add drift options to spring transition

### DIFF
--- a/transitions/WallTransition.js
+++ b/transitions/WallTransition.js
@@ -179,6 +179,8 @@ define(function(require, exports, module) {
         if (def.dampingRatio === undefined) def.dampingRatio = defaults.dampingRatio;
         if (def.velocity === undefined) def.velocity = defaults.velocity;
         if (def.restitution === undefined) def.restitution = defaults.restitution;
+        if (def.drift === undefined) def.drift = Wall.DEFAULT_OPTIONS.drift;
+        if (def.slop === undefined) def.slop = Wall.DEFAULT_OPTIONS.slop;
 
         //setup spring
         this.spring.setOptions({
@@ -188,7 +190,9 @@ define(function(require, exports, module) {
 
         //setup wall
         this.wall.setOptions({
-            restitution : def.restitution
+            restitution : def.restitution,
+            drift: def.drift,
+            slop: def.slop
         });
 
         //setup particle


### PR DESCRIPTION
This change edits options on WallTransition, giving the user the option to create a stable, endless bounce.  It exposes drift, slop, and restitution to the user of SpringTransition.
