### PR TITLE
Centering Quaternion example

### DIFF
--- a/examples/math/Quaternion/example.js
+++ b/examples/math/Quaternion/example.js
@@ -61,7 +61,12 @@ define(function(require, exports, module) {
         return toggle ? Transform.identity : quaternion.getTransform();
     });
 
-    mainContext.add(new Modifier({origin: [.5, .5]})).add(modifier).add(surface);
+    mainContext.add(
+      new Modifier({
+        origin: [.5, .5],
+        align: [.5, .5]
+      })
+    ).add(modifier).add(surface);
 
     var toggle = true;
     Engine.on('click', function() {


### PR DESCRIPTION
Modifier has not been adapted since the apparition of `align`.
