### PR TITLE
Centering Quaternion's rotating box example

### DIFF
--- a/examples/math/Quaternion/rotating-box.js
+++ b/examples/math/Quaternion/rotating-box.js
@@ -49,7 +49,8 @@ define(function(require, exports, module) {
     var smallQuaternion = new Quaternion(185, 1, 1, 1);
 
     var rotationModifier = new Modifier({
-        origin: [0.5, 0.5]
+        origin: [.5, .5],
+        align: [.5, .5]
     });
 
     // Bind the box's rotation to the quaternion


### PR DESCRIPTION
Adding the missing align.
