### PR TITLE
Providing explanations in Utility.after example

### DIFF
--- a/examples/utilities/Utility/after.js
+++ b/examples/utilities/Utility/after.js
@@ -37,8 +37,27 @@
 define(function(require, exports, module) {
     var Engine  = require('famous/core/Engine');
     var Utility = require('famous/utilities/Utility');
+    var Surface = require('famous/core/Surface');
+    var StateModifier = require('famous/modifiers/StateModifier');
 
-    Engine.createContext();
+    var mySurface = new Surface({
+        size: [undefined, 100],
+        properties: {
+            backgroundColor: '#fa5c4f',
+            lineHeight: '100px',
+            textAlign: 'center',
+            color: '#eee'
+        },
+        content: 'Take only the 5th click into account.'
+    });
+
+    var myModifier = new StateModifier({
+        origin: [0, 0],
+        align: [0, 0]
+    });
+
+    var mainContext = Engine.createContext();
+    mainContext.add(myModifier).add(mySurface);
 
     var fn = Utility.after(5, function() {
         alert('Was called on 5th try');


### PR DESCRIPTION
Without looking at the code, the intent wasn't clear. With a little explanation on screen, I think it's better.
