### PR TITLE
Prevent double tap zoom on iOS 8 mobile Safari

### DIFF
--- a/src/inputs/FastClick.js
+++ b/src/inputs/FastClick.js
@@ -38,6 +38,8 @@ define(function(require, exports, module) {
       });
 
       window.addEventListener('touchend', function(event) {
+          event.preventDefault();
+
           var currTime = _now();
           for (var i = 0; i < event.changedTouches.length; i++) {
               var touch = event.changedTouches[i];


### PR DESCRIPTION
I added two views into a render node and display the render node using RenderController. One view fill the whole screen and the other one I put outside of screen bounds on the right side. When I test my app directly from mobile Safari and do double tap, the screen slide to left and the second view (the hidden) get shown. This pull request is my quick attempt to prevent that from happening. It seems the double tap zoom still triggered even though I already set the meta tag to prevent it.
