### PR TITLE
fetch size from property of target if still not found

### DIFF
--- a/src/core/RenderNode.js
+++ b/src/core/RenderNode.js
@@ -97,6 +97,7 @@ define(function(require, exports, module) {
         var target = this.get();
         if (target && target.getSize) result = target.getSize();
         if (!result && this._child && this._child.getSize) result = this._child.getSize();
+        if (!result && target.size) result = target.size;
         return result;
     };
 


### PR DESCRIPTION
Sometimes the size is present on the target but is missed leading to the function returning null