### PR TITLE
CSS rules repeated

### DIFF
--- a/src/core/famous.css
+++ b/src/core/famous.css
@@ -36,8 +36,6 @@
     height: 0px;
     margin: 0px;
     padding: 0px;
-    -webkit-transform-style: preserve-3d;
-    transform-style: preserve-3d;
 }
 
 .famous-surface {


### PR DESCRIPTION
In the `.famous-group`, the following properties are repeated:

``` css
    -webkit-transform-style: preserve-3d;
    transform-style: preserve-3d;
```

They are already declared in the rule `.famous-container, .famous-group`.
