### PR TITLE
Fix page index reference to be the current page index

### DIFF
--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -470,16 +470,16 @@ define(function(require, exports, module) {
      * @method goToPage
      */
     Scrollview.prototype.goToPage = function goToPage(index) {
-        var currentIndex = this.getCurrentIndex();
+        var currentPageIndex = this.getCurrentIndex() + 1;
         var i;
 
-        if (currentIndex > index) {
-            for (i = 0; i < currentIndex - index; i++)
+        if (currentPageIndex > index) {
+            for (i = 0; i < currentPageIndex - index; i++)
                 this.goToPreviousPage();
         }
 
-        if (currentIndex < index) {
-            for (i = 0; i < index - currentIndex; i++)
+        if (currentPageIndex < index) {
+            for (i = 0; i < index - currentPageIndex; i++)
                 this.goToNextPage();
         }
     };


### PR DESCRIPTION
This patch assumes we are passing the absolute page index value to the `gotToPage` function. Otherwise, we will need to refactor the function to use the zero based index instead.
getCurrentIndex is the zero based index of the ViewSequence in the scrollview

goToPage should be using the current page index (getCurrentIndex() + 1) for transitioning to the absolute page.

fixes #393 
fixes #383 by making it a little clearer
