### PR TITLE
Using size = [undefined, size] on a Surface, causes the width (undefined) to be set initially but never updates after that

### DIFF
--- a/src/core/Surface.js
+++ b/src/core/Surface.js
@@ -347,25 +347,29 @@ define(function(require, exports, module) {
             if (size[0] === undefined) size[0] = origSize[0];
             if (size[1] === undefined) size[1] = origSize[1];
             if (size[0] === true || size[1] === true) {
-                if (size[0] === true && (this._trueSizeCheck || this._size[0] === 0)) {
-                    var width = target.offsetWidth;
-                    if (this._size && this._size[0] !== width) {
-                        this._size[0] = width;
-                        this._sizeDirty = true;
+                if (size[0] === true){
+                    if (this._trueSizeCheck || (this._size[0] === 0)) {
+                        var width = target.offsetWidth;
+                        if (this._size && this._size[0] !== width) {
+                            this._size[0] = width;
+                            this._sizeDirty = true;
+                        }
+                        size[0] = width;
+                    } else {
+                        if (this._size) size[0] = this._size[0];
                     }
-                    size[0] = width;
-                } else {
-                    if (this._size) size[0] = this._size[0];
                 }
-                if (size[1] === true && (this._trueSizeCheck || this._size[1] === 0)) {
-                    var height = target.offsetHeight;
-                    if (this._size && this._size[1] !== height) {
-                        this._size[1] = height;
-                        this._sizeDirty = true;
+                if (size[1] === true){
+                    if (this._trueSizeCheck || (this._size[1] === 0)) {
+                        var height = target.offsetHeight;
+                        if (this._size && this._size[1] !== height) {
+                            this._size[1] = height;
+                            this._sizeDirty = true;
+                        }
+                        size[1] = height;
+                    } else {
+                        if (this._size) size[1] = this._size[1];
                     }
-                    size[1] = height;
-                } else {
-                    if (this._size) size[1] = this._size[1];
                 }
                 this._trueSizeCheck = false;
             }


### PR DESCRIPTION
When only one of the two size-arguments is set to true, it would effectively cause undefined from stop working on the other argument. This is because the else-statement is always executed, regardless of whether true is defined on that size-argument.
