### PR TITLE
Fix removeBody id reference to be the objects id

### DIFF
--- a/src/physics/PhysicsEngine.js
+++ b/src/physics/PhysicsEngine.js
@@ -136,7 +136,11 @@ define(function(require, exports, module) {
         var array = (body.isBody) ? this._bodies : this._particles;
         var index = array.indexOf(body);
         if (index > -1) {
-            for (var agent in this._agentData) this.detachFrom(agent.id, body);
+            for (var agentKey in this._agentData) {
+                if (this._agentData.hasOwnProperty(agentKey)) {
+                    this.detachFrom(this._agentData[agentKey].id, body);
+                }
+            }
             array.splice(index,1);
         }
         if (this.getBodies().length === 0) this._hasBodies = false;


### PR DESCRIPTION
When using for-in on an object of objects, the key is returned as the property, not the object itself because it has it's own properties.

A hasOwnProperty check is best practice. but not really needed when you are sure it is going to be an object.

resolve #449
close #448 
