### PR TITLE
remove default origin from particle

### DIFF
--- a/src/physics/bodies/Particle.js
+++ b/src/physics/bodies/Particle.js
@@ -61,7 +61,6 @@ define(function(require, exports, module) {
             size : [true, true],
             target : {
                 transform : this.transform,
-                origin : [0.5, 0.5],
                 target : null
             }
         };


### PR DESCRIPTION
When you're using a particle to manipulate a position of a Surface, this line forces a center origin on the child components of that particle. Removing this line allows the origin higher up in the render tree to cascade down. 