### PR TITLE
physics transitions end on specified value

### DIFF
--- a/src/transitions/SnapTransition.js
+++ b/src/transitions/SnapTransition.js
@@ -152,6 +152,7 @@ define(function(require, exports, module) {
             if (this._callback) {
                 var cb = this._callback;
                 this._callback = undefined;
+                this.set(this.endState);
                 cb();
             }
             return;

--- a/src/transitions/SnapTransition.js
+++ b/src/transitions/SnapTransition.js
@@ -136,7 +136,7 @@ define(function(require, exports, module) {
         if (definition.period === undefined)       definition.period       = defaults.period;
         if (definition.dampingRatio === undefined) definition.dampingRatio = defaults.dampingRatio;
         if (definition.velocity === undefined)     definition.velocity     = defaults.velocity;
-
+        if (definition.tolerance) this._restTolerance = definition.tolerance;
         //setup spring
         this.spring.setOptions({
             period       : definition.period,
@@ -152,7 +152,6 @@ define(function(require, exports, module) {
             if (this._callback) {
                 var cb = this._callback;
                 this._callback = undefined;
-                this.set(this.endState);
                 cb();
             }
             return;

--- a/src/transitions/SpringTransition.js
+++ b/src/transitions/SpringTransition.js
@@ -127,7 +127,6 @@ define(function(require, exports, module) {
             if (this._callback) {
                 var cb = this._callback;
                 this._callback = undefined;
-                this.set(this.endState);
                 cb();
             }
             return;
@@ -152,6 +151,7 @@ define(function(require, exports, module) {
             definition.period = 150;
             console.warn('The period of a SpringTransition is capped at 150 ms. Use a SnapTransition for faster transitions');
         }
+        if (definition.tolerance) this._restTolerance = definition.tolerance;
 
         //setup spring
         this.spring.setOptions({

--- a/src/transitions/SpringTransition.js
+++ b/src/transitions/SpringTransition.js
@@ -127,6 +127,7 @@ define(function(require, exports, module) {
             if (this._callback) {
                 var cb = this._callback;
                 this._callback = undefined;
+                this.set(this.endState);
                 cb();
             }
             return;

--- a/src/transitions/WallTransition.js
+++ b/src/transitions/WallTransition.js
@@ -161,6 +161,7 @@ define(function(require, exports, module) {
             if (this._callback) {
                 var cb = this._callback;
                 this._callback = undefined;
+                this.set(this.endState);
                 cb();
             }
             return;

--- a/src/transitions/WallTransition.js
+++ b/src/transitions/WallTransition.js
@@ -161,11 +161,11 @@ define(function(require, exports, module) {
             if (this._callback) {
                 var cb = this._callback;
                 this._callback = undefined;
-                this.set(this.endState);
                 cb();
             }
             return;
         }
+
         var energy = _getEnergy.call(this);
         if (energy < this._absRestTolerance) {
             _sleep.call(this);
@@ -182,6 +182,7 @@ define(function(require, exports, module) {
         if (def.restitution === undefined) def.restitution = defaults.restitution;
         if (def.drift === undefined) def.drift = Wall.DEFAULT_OPTIONS.drift;
         if (def.slop === undefined) def.slop = Wall.DEFAULT_OPTIONS.slop;
+        if (def.tolerance) this._restTolerance = def.tolerance;
 
         //setup spring
         this.spring.setOptions({


### PR DESCRIPTION
Added a set call to the physics transitions so they will end on the value given in Transitionable#set rather than a value *close* to the given value.