### PR TITLE
Transitionable: Fix doc; Make API more consistent

### DIFF
--- a/src/transitions/Transitionable.js
+++ b/src/transitions/Transitionable.js
@@ -126,6 +126,7 @@ define(function(require, exports, module) {
      *    instantaneous.
      * @param {function()=} callback Zero-argument function to call on observed
      *    completion (t=1)
+     * @return {Transitionable} this
      */
     Transitionable.prototype.set = function set(endState, transition, callback) {
         if (!transition) {
@@ -168,9 +169,10 @@ define(function(require, exports, module) {
      * @param {number} duration delay time (ms)
      * @param {function} callback Zero-argument function to call on observed
      *    completion (t=1)
+     * @return {Transitionable} this
      */
     Transitionable.prototype.delay = function delay(duration, callback) {
-        this.set(this.get(), {duration: duration,
+        return this.set(this.get(), {duration: duration,
             curve: function() {
                 return 0;
             }},
@@ -213,6 +215,8 @@ define(function(require, exports, module) {
      * Halt transition at current state and erase all pending actions.
      *
      * @method halt
+     *
+     * @return {Transitionable} this
      */
     Transitionable.prototype.halt = function halt() {
         return this.set(this.get());


### PR DESCRIPTION
* delay() should really return this.

Why?

I should be able to do something like this:

```javascript
var t = new Transitionable(0);
t
.set(1, {duration: 100})
.delay(200)
.set(2, {duration: 100});
```

Currently this is not possible, since delay does not return this.

* Fix API (minor improvements)