### PR TITLE
Stop firefox from setting z-index on every frame

### DIFF
--- a/src/core/ElementOutput.js
+++ b/src/core/ElementOutput.js
@@ -182,13 +182,7 @@ define(function(require, exports, module) {
      */
 
     var _setMatrix;
-    if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-        _setMatrix = function(element, matrix) {
-            element.style.zIndex = (matrix[14] * 1000000) | 0;    // fix for Firefox z-buffer issues
-            element.style.transform = _formatCSSTransform(matrix);
-        };
-    }
-    else if (usePrefix) {
+    if (usePrefix) {
         _setMatrix = function(element, matrix) {
             element.style.webkitTransform = _formatCSSTransform(matrix);
         };


### PR DESCRIPTION
This hack is no longer necessary and is causing famo.us to be broken on firefox >= 34
