### PR TITLE
[develop] Scrollview - small patches

### DIFF
--- a/src/views/Scroller.js
+++ b/src/views/Scroller.js
@@ -71,7 +71,7 @@ define(function(require, exports, module) {
 
     function _output(node, offset, target) {
         var size = node.getSize ? node.getSize() : this._contextSize;
-        var transform = this._outputFunction(offset);
+        var transform = this._outputFunction(offset, node.index);
         target.push({transform: transform, target: node.render()});
         return _sizeForDir.call(this, size);
     }
@@ -130,14 +130,14 @@ define(function(require, exports, module) {
      */
     Scroller.prototype.outputFrom = function outputFrom(fn, masterFn) {
         if (!fn) {
-            fn = function(offset) {
+            fn = function(offset, index) {
                 return (this.options.direction === Utility.Direction.X) ? Transform.translate(offset, 0) : Transform.translate(0, offset);
             }.bind(this);
             if (!masterFn) masterFn = fn;
         }
         this._outputFunction = fn;
-        this._masterOutputFunction = masterFn ? masterFn : function(offset) {
-            return Transform.inverse(fn(-offset));
+        this._masterOutputFunction = masterFn ? masterFn : function(offset, index) {
+            return Transform.inverse(fn(-offset, index));
         };
     };
 

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -79,6 +79,9 @@ define(function(require, exports, module) {
         this.options = Object.create(Scrollview.DEFAULT_OPTIONS);
         this._optionsManager = new OptionsManager(this.options);
 
+        // override default options with passed-in custom options
+        if (options) this.setOptions(options);
+        
         // create sub-components
         this._scroller = new Scroller(this.options);
 
@@ -140,9 +143,6 @@ define(function(require, exports, module) {
         EventHandler.setOutputHandler(this, this._eventOutput);
 
         _bindEvents.call(this);
-
-        // override default options with passed-in custom options
-        if (options) this.setOptions(options);
     }
 
     Scrollview.DEFAULT_OPTIONS = {

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -81,7 +81,7 @@ define(function(require, exports, module) {
 
         // override default options with passed-in custom options
         if (options) this.setOptions(options);
-        
+
         // create sub-components
         this._scroller = new Scroller(this.options);
 


### PR DESCRIPTION
- Changed order of operation to patch options before trying to use them
- Added `index` in a non-breaking way to the output function's arguments
