### PR TITLE
[develop] Draggable - Fixes and new Threshold and Autocomplete options

### DIFF
--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -35,16 +35,16 @@ define(function(require, exports, module) {
      */
     function Draggable(options) {
         this.options = Object.create(Draggable.DEFAULT_OPTIONS);
-        if (options) this.setOptions(options);
+        this.sync = new GenericSync(['mouse', 'touch'], {scale : this.options.scale});
+        this.eventOutput = new EventHandler();
 
+        EventHandler.setInputHandler(this,  this.sync);
+        EventHandler.setOutputHandler(this, this.eventOutput);
+
+        if (options) this.setOptions(options);
         this._positionState = new Transitionable([0,0]);
         this._differential  = [0,0];
         this._active = true;
-
-        this.sync = new GenericSync(['mouse', 'touch'], {scale : this.options.scale});
-        this.eventOutput = new EventHandler();
-        EventHandler.setInputHandler(this,  this.sync);
-        EventHandler.setOutputHandler(this, this.eventOutput);
 
         _bindEvents.call(this);
     }

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -192,13 +192,7 @@ define(function(require, exports, module) {
      */
     Draggable.prototype.setOptions = function setOptions(options) {
         var currentOptions = this.options;
-        if (options.projection !== undefined) {
-            var proj = options.projection;
-            this.options.projection = 0;
-            ['x', 'y'].forEach(function(val) {
-                if (proj.indexOf(val) !== -1) currentOptions.projection |= _direction[val];
-            });
-        }
+
         if (options.scale  !== undefined) {
             currentOptions.scale  = options.scale;
             this.sync.setOptions({
@@ -216,6 +210,7 @@ define(function(require, exports, module) {
             options.yRange = options.range[1];
         }
 
+        if (options.projection !== undefined) currentOptions.projection = options.projection;
         if (options.xRange !== undefined) currentOptions.xRange = options.xRange;
         if (options.yRange !== undefined) currentOptions.yRange = options.yRange;
         if (options.snapX  !== undefined) currentOptions.snapX  = options.snapX;

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -20,7 +20,7 @@ define(function(require, exports, module) {
 
     /**
      * Makes added render nodes responsive to drag beahvior.
-     *   Emits events 'start', 'update', 'end'.
+     *   Emits events 'start', 'update', 'end' and 'reject'.
      * @class Draggable
      * @constructor
      * @param {Object} [options] options configuration object.
@@ -111,7 +111,6 @@ define(function(require, exports, module) {
             && absPosition[1] < options.threshold[1];
 
         if (thresholdX || thresholdY) {
-        	console.log('reject');
         	this.eventOutput.emit('reject', {position : position});
         	return;
         }

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -24,6 +24,8 @@ define(function(require, exports, module) {
      * @class Draggable
      * @constructor
      * @param {Object} [options] options configuration object.
+     * @param {Array.Number} [options.autocomplete] Automatically take over and snap to the ranges when the displacement passes a ratio (between 0 and 1) in its direction.
+     * Default is off (no autocomplete): [1.0, 1.0].
      * @param {Number} [options.snapX] grid width for snapping during drag.
      * @param {Number} [options.snapY] grid height for snapping during drag.
      * @param {Array.Number} [options.snap] shorthand for snapX and snapY.
@@ -50,8 +52,8 @@ define(function(require, exports, module) {
         }
 
         if (options.range) {
-        	options.xRange = options.range[0];
-        	options.yRange = options.range[1];
+            options.xRange = options.range[0];
+            options.yRange = options.range[1];
         }
 
         if (options) this.setOptions(options);
@@ -74,14 +76,15 @@ define(function(require, exports, module) {
     var _clamp = Utilities.clamp;
 
     Draggable.DEFAULT_OPTIONS = {
-        projection  : _direction.x | _direction.y,
-        scale       : 1,
-        xRange      : null,
-        yRange      : null,
-        snapX       : 0,
-        snapY       : 0,
-        transition  : {duration : 0},
-        threshold   : [0, 0]
+        projection   : _direction.x | _direction.y,
+        scale        : 1,
+        xRange       : null,
+        yRange       : null,
+        snapX        : 0,
+        snapY        : 0,
+        transition   : {duration : 0},
+        threshold    : [0, 0],
+        autocomplete : [1.0, 1.0]
     };
 
     function _mapDifferential(differential) {
@@ -150,6 +153,18 @@ define(function(require, exports, module) {
             pos[1] = _clamp(pos[1], yRange);
         }
 
+        //handle auto completion
+        var autocomplete = options.autocomplete;
+        var ranges = [options.xRange, options.yRange];
+        for (var i = 0; i < 2; i++) {
+            var ratio = autocomplete[0];
+            var range = ranges[i][+(newDifferential[i] > 0)];
+
+            if (Math.abs(pos[i] / range) > ratio) {
+                pos[i] = range;
+            }
+        }
+
         this.setPosition(pos, options.transition);
         this.eventOutput.emit('update', {
             position : position,
@@ -197,8 +212,8 @@ define(function(require, exports, module) {
         }
 
         if (options.range) {
-        	options.xRange = options.range[0];
-        	options.yRange = options.range[1];
+            options.xRange = options.range[0];
+            options.yRange = options.range[1];
         }
 
         if (options.xRange !== undefined) currentOptions.xRange = options.xRange;
@@ -207,6 +222,7 @@ define(function(require, exports, module) {
         if (options.snapY  !== undefined) currentOptions.snapY  = options.snapY;
         if (options.threshold  !== undefined) currentOptions.threshold  = options.threshold;
         if (options.transition  !== undefined) currentOptions.transition  = options.transition;
+        if (options.autocomplete !== undefined) currentOptions.autocomplete = options.autocomplete;
     };
 
     /**

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -46,17 +46,20 @@ define(function(require, exports, module) {
         EventHandler.setInputHandler(this,  this.sync);
         EventHandler.setOutputHandler(this, this.eventOutput);
 
-        if (options.snap) {
-            options.snapX = options.snap[0];
-            options.snapY = options.snap[1];
+        if (options) {
+            if (options.snap) {
+                options.snapX = options.snap[0];
+                options.snapY = options.snap[1];
+            }
+
+            if (options.range) {
+                options.xRange = options.range[0];
+                options.yRange = options.range[1];
+            }
+
+            this.setOptions(options);
         }
 
-        if (options.range) {
-            options.xRange = options.range[0];
-            options.yRange = options.range[1];
-        }
-
-        if (options) this.setOptions(options);
         this._positionState = new Transitionable([0,0]);
         this._differential  = [0,0];
         this._active = true;

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -184,6 +184,7 @@ define(function(require, exports, module) {
         if (options.snapX  !== undefined) currentOptions.snapX  = options.snapX;
         if (options.snapY  !== undefined) currentOptions.snapY  = options.snapY;
         if (options.threshold  !== undefined) currentOptions.threshold  = options.threshold;
+        if (options.transition  !== undefined) currentOptions.transition  = options.transition;
     };
 
     /**

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -24,12 +24,14 @@ define(function(require, exports, module) {
      * @class Draggable
      * @constructor
      * @param {Object} [options] options configuration object.
-     * @param {Number} [options.snapX] grid width for snapping during drag
-     * @param {Number} [options.snapY] grid height for snapping during drag
-     * @param {Array.Number} [options.xRange] maxmimum [negative, positive] x displacement from start of drag
-     * @param {Array.Number} [options.yRange] maxmimum [negative, positive] y displacement from start of drag
-     * @param {Array.Number} [options.threshold] minimum absolute [x, y] displacement to validate movement. 
-     * @param {Number} [options.scale] one pixel of input motion translates to this many pixels of output drag motion
+     * @param {Number} [options.snapX] grid width for snapping during drag.
+     * @param {Number} [options.snapY] grid height for snapping during drag.
+     * @param {Array.Number} [options.snap] shorthand for snapX and snapY.
+     * @param {Array.Number} [options.xRange] maxmimum [negative, positive] x displacement from start of drag.
+     * @param {Array.Number} [options.yRange] maxmimum [negative, positive] y displacement from start of drag.
+     * @param {Array.Number} [options.range] shorthand for xRange and yRange.
+     * @param {Array.Number} [options.threshold] minimum absolute [x, y] displacement to validate movement.
+     * @param {Number} [options.scale] one pixel of input motion translates to this many pixels of output drag motion.
      * @param {Number} [options.projection] User should set to Draggable._direction.x or
      *    Draggable._direction.y to constrain to one axis.
      *
@@ -41,6 +43,16 @@ define(function(require, exports, module) {
 
         EventHandler.setInputHandler(this,  this.sync);
         EventHandler.setOutputHandler(this, this.eventOutput);
+
+        if (options.snap) {
+            options.snapX = options.snap[0];
+            options.snapY = options.snap[1];
+        }
+
+        if (options.range) {
+        	options.xRange = options.range[0];
+        	options.yRange = options.range[1];
+        }
 
         if (options) this.setOptions(options);
         this._positionState = new Transitionable([0,0]);
@@ -111,8 +123,8 @@ define(function(require, exports, module) {
             && absPosition[1] < options.threshold[1];
 
         if (thresholdX || thresholdY) {
-        	this.eventOutput.emit('reject', {position : position});
-        	return;
+            this.eventOutput.emit('reject', {position : position});
+            return;
         }
 
         //buffer the differential if snapping is set
@@ -140,8 +152,8 @@ define(function(require, exports, module) {
 
         this.setPosition(pos, options.transition);
         this.eventOutput.emit('update', {
-        	position : position,
-        	endPosition : pos
+            position : position,
+            endPosition : pos
         });
     }
 
@@ -178,6 +190,17 @@ define(function(require, exports, module) {
                 scale: options.scale
             });
         }
+
+        if (options.snap) {
+            options.snapX = options.snap[0];
+            options.snapY = options.snap[1];
+        }
+
+        if (options.range) {
+        	options.xRange = options.range[0];
+        	options.yRange = options.range[1];
+        }
+
         if (options.xRange !== undefined) currentOptions.xRange = options.xRange;
         if (options.yRange !== undefined) currentOptions.yRange = options.yRange;
         if (options.snapX  !== undefined) currentOptions.snapX  = options.snapX;


### PR DESCRIPTION
- Changed order of operation to patch options before trying to use them
- Fixed default transition (wasn't being registered)
- Added `options.threshold`
- Added shorthand options
- Added `options.autocomplete'
- Fixed `options.projection` <-- MAY BREAK STUFF

Threshold example:

``` javascript
var draggable = new Draggable({
    xRange : [-200, 0],
    yRange : [0, 0],
    threshold : [50, 0],
    transition : {
        duration : 200
    }
});
```

With shorthand options:

``` javascript
var draggable = new Draggable({
    range : [[-200, 0], [0, 0]],
    threshold : [50, 0],
    transition : {
        duration : 200
    }
});
```

This is an example I use in my own app to drag out a menu from the right side of the screen.

The app essentially has a vertical scroller, to which the draggable is subscribed.
The scroller moves to the left when dragged, to reveal a menu underneath.

However, without threshold any displacement along the x-axis, would result in dragging, even when the user's intention was to vertically scroll through the content. By setting the x-threshold to `50`, the user must explicitly drag 50 pixels to the left **or** right for the draggable to even start responding to the input.

The transition now makes sure that those 50 pixels are not an instant movement, but a gently flowing movement instead. **This transition also applies to the snapping of the draggable!**

Live example:
http://skelware.com/famo.us/draggable/example/1/
- Doubleclick to transition between 'pages' (currently page a and page b alternate).
  This is a lightbox and the pages are vertical scrollviews.
- Drag left to open the menu
  You need to drag at least 50 pixels
- Drag right to close the menu
  You do _not_ need to drag at least 50 pixels
