### PR TITLE
Fix Matrix.transpose

### DIFF
--- a/src/math/Matrix.js
+++ b/src/math/Matrix.js
@@ -127,7 +127,7 @@ define(function(require, exports, module) {
      * @return {Matrix} result of transpose, as a handle to the internal register
      */
     Matrix.prototype.transpose = function transpose() {
-        var result = [];
+        var result = [[], [], []];
         var M = this.get();
         for (var row = 0; row < 3; row++) {
             for (var col = 0; col < 3; col++) {


### PR DESCRIPTION
transpose didn't work.

e.g. `result[0]` was `undefined` -> `result[0][0]` doesn't work