### PR TITLE
Vector: Always default to 0 0 0

### DIFF
--- a/src/math/Vector.js
+++ b/src/math/Vector.js
@@ -20,11 +20,10 @@ define(function(require, exports, module) {
      * @param {number} z z element value
      */
     function Vector(x,y,z) {
-        if (arguments.length === 1 && x !== undefined) this.set(x);
-        else {
-            this.x = x || 0;
-            this.y = y || 0;
-            this.z = z || 0;
+        if (arguments.length === 1 && x !== undefined) {
+            this.set(x);
+        } else {
+            _setXYZ.call(this, x, y, z);
         }
         return this;
     }
@@ -260,9 +259,9 @@ define(function(require, exports, module) {
     };
 
     function _setXYZ(x,y,z) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
+        this.x = x || 0;
+        this.y = y || 0;
+        this.z = z || 0;
         return this;
     }
 


### PR DESCRIPTION
Vectors should always default to 0 0 0, not only when instantiated via explicit arguments in the constructor.

The feature that the constructor accepts objects, vectors, arrays and explicit arguments is undocumented, not sure how to do that in JSDoc.