### PR TITLE
Matrix.multiply: Accept 2D arrays and matrices

### DIFF
--- a/src/math/Matrix.js
+++ b/src/math/Matrix.js
@@ -25,8 +25,6 @@ define(function(require, exports, module) {
                 [0,1,0],
                 [0,0,1]
             ];
-
-        return this;
     }
 
     var _register = new Matrix();
@@ -103,7 +101,8 @@ define(function(require, exports, module) {
      */
     Matrix.prototype.multiply = function multiply(M2) {
         var M1 = this.get();
-        var result = [[]];
+        if (M2 instanceof Matrix) M2 = M2.get();
+        var result = [];
         for (var i = 0; i < 3; i++) {
             result[i] = [];
             for (var j = 0; j < 3; j++) {


### PR DESCRIPTION
Matrix.multiply is supposed to accept an instance of Matrix (according to doc), which doesn't seem to work, since it works with a 2D array. A previous `.get()` call seems necessary.

**EDIT**: Also removed `return this` from constructor and another minor fix.