### PR TITLE
Fix Matrix.set

### DIFF
--- a/src/math/Matrix.js
+++ b/src/math/Matrix.js
@@ -48,10 +48,13 @@ define(function(require, exports, module) {
      *
      * @method set
      *
+     * @chainable
      * @param {Array.array} values matrix values as array of rows.
+     * @return {Matrix} this
      */
     Matrix.prototype.set = function set(values) {
         this.values = values;
+        return this;
     };
 
     /**


### PR DESCRIPTION
I honestly don't really know why the Matrix is implemented using the private `_register`, but it **can't** work the way it's currently implemented.

`.set` needs to return this, otherwise `.multiply` **can't** return this (same with ``.transpose``).

(please see my other PRs)