### PR TITLE
Add Engine.removeFPSCap

### DIFF
--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -263,6 +263,16 @@ define(function(require, exports, module) {
     };
 
     /**
+     * Remove FPS cap set via Engine.setFPSCap
+     *
+     * @static
+     * @method removeFPSCap
+     */
+    Engine.removeFPSCap = function removeFPSCap() {
+        frameTimeLimit = undefined;
+    };
+
+    /**
      * Return engine options.
      *
      * @static


### PR DESCRIPTION
Currently there is no way to remove the previously set FPS cap, since frameTimeLimit is private.