### PR TITLE
Rewrite DesktopEmulationMode (breaking API change)

### DIFF
--- a/src/inputs/DesktopEmulationMode.js
+++ b/src/inputs/DesktopEmulationMode.js
@@ -1,17 +1,32 @@
 define(function(require, exports, module) {
-    var hasTouch = 'ontouchstart' in window;
-
-    function kill(type) {
-        window.addEventListener(type, function(event) {
-            event.stopPropagation();
-            return false;
-        }, true);
+    function listener(event) {
+        event.stopPropagation();
+        return false;
     }
 
-    if (hasTouch) {
-        kill('mousedown');
-        kill('mousemove');
-        kill('mouseup');
-        kill('mouseleave');
+    var eventNames = ['mousedown', 'mousemove', 'mouseup', 'mouseleave'];
+
+    function mute(eventName) {
+        window.addEventListener(eventName, listener, true);
     }
+
+    function unmute(eventName) {
+        window.removeEventListener(eventName, listener, true);
+    }
+
+    function enable() {
+        eventNames.forEach(mute);
+    }
+
+    function disable() {
+        eventNames.forEach(unmute);
+    }
+
+    module.exports = {
+        enable: enable,
+        disable: disable
+    };
+
+    /* TODO Remove initial enable call when deprecation is complete */
+    enable();
 });


### PR DESCRIPTION
related: #554 and Famous/famous-angular#222

* allows to reverse DesktopEmulationMode
* `require` doesn't have any side-effects
* makes it testable

**Before:**
```javascript
require('famous/inputs/DesktopEmulationMode');
```

**After:**
```javascript
var DesktopEmulationMode = require('famous/inputs/DesktopEmulationMode');

DesktopEmulationMode.enable();

setTimeout(DesktopEmulationMode.disable, 1000);
```

**This is a breaking API change!!**
