### PR TITLE
docs: Transform.multiply only supports 2 transform matrix types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/src/core/ElementOutput.js
+++ b/src/core/ElementOutput.js
@@ -182,13 +182,7 @@ define(function(require, exports, module) {
      */
 
     var _setMatrix;
-    if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-        _setMatrix = function(element, matrix) {
-            element.style.zIndex = (matrix[14] * 1000000) | 0;    // fix for Firefox z-buffer issues
-            element.style.transform = _formatCSSTransform(matrix);
-        };
-    }
-    else if (usePrefix) {
+    if (usePrefix) {
         _setMatrix = function(element, matrix) {
             element.style.webkitTransform = _formatCSSTransform(matrix);
         };

--- a/src/core/Transform.js
+++ b/src/core/Transform.js
@@ -67,7 +67,7 @@ define(function(require, exports, module) {
     };
 
     /**
-     * Fast-multiply two or more Transform matrix types to return a
+     * Fast-multiply two Transform matrix types to return a
      *    Matrix, assuming bottom row on each is [0 0 0 1].
      *
      * @method multiply


### PR DESCRIPTION
This is from famous-angular issue 301.  

The documentation said that a user can pass in multiple matrix types into Transform.multiply() when it only takes 2.  I spoke to Mike about this and it was intentionally changed to this behavior.