### PR TITLE
fix: Update Draggable, error at creation with scale

### DIFF
--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -153,7 +153,7 @@ define(function(require, exports, module) {
         }
         if (options.scale  !== undefined) {
             currentOptions.scale  = options.scale;
-            if (this.sync !== undefined){
+            if (this.sync !== undefined) {
                 this.sync.setOptions({
                     scale: options.scale
                 });

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -153,9 +153,10 @@ define(function(require, exports, module) {
         }
         if (options.scale  !== undefined) {
             currentOptions.scale  = options.scale;
-            this.sync.setOptions({
-                scale: options.scale
-            });
+            if(this.sync !== undefined)
+                this.sync.setOptions({
+                    scale: options.scale
+                });
         }
         if (options.xRange !== undefined) currentOptions.xRange = options.xRange;
         if (options.yRange !== undefined) currentOptions.yRange = options.yRange;

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -153,10 +153,11 @@ define(function(require, exports, module) {
         }
         if (options.scale  !== undefined) {
             currentOptions.scale  = options.scale;
-            if(this.sync !== undefined)
+            if (this.sync !== undefined){
                 this.sync.setOptions({
                     scale: options.scale
                 });
+            }    
         }
         if (options.xRange !== undefined) currentOptions.xRange = options.xRange;
         if (options.yRange !== undefined) currentOptions.yRange = options.yRange;


### PR DESCRIPTION
While creating a draggable with scale in the options array (cf: http://jsfiddle.net/dajc65ur/), it tries to set the MouseSync which is not yet initialized. I've added a test to determine if it has been created or not.