### PR TITLE
Fix options for docs

### DIFF
--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -280,11 +280,11 @@ define(function(require, exports, module) {
      * @static
      * @method setOptions
      *
-     * @param {Object} [options] overrides of default options
-     * @param {Number} [options.fpsCap]  maximum fps at which the system should run
-     * @param {boolean} [options.runLoop=true] whether the run loop should continue
-     * @param {string} [options.containerType="div"] type of container element.  Defaults to 'div'.
-     * @param {string} [options.containerClass="famous-container"] type of container element.  Defaults to 'famous-container'.
+     * @param {Object} options overrides of default options
+     * @param {Number} options.fpsCap  maximum fps at which the system should run
+     * @param {boolean} options.runLoop=true whether the run loop should continue
+     * @param {string} options.containerType="div" type of container element.  Defaults to 'div'.
+     * @param {string} options.containerClass="famous-container" type of container element.  Defaults to 'famous-container'.
      */
     Engine.setOptions = function setOptions(options) {
         return optionsManager.setOptions.apply(optionsManager, arguments);

--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -22,7 +22,7 @@ define(function(require, exports, module) {
      * @class Group
      * @extends Surface
      * @constructor
-     * @param {Object} [options] Surface options array (see Surface})
+     * @param {Object} options Surface options array (see Surface})
      */
     function Group(options) {
         Surface.call(this, options);

--- a/src/core/Modifier.js
+++ b/src/core/Modifier.js
@@ -25,11 +25,11 @@ define(function(require, exports, module) {
      *
      * @class Modifier
      * @constructor
-     * @param {Object} [options] overrides of default options
-     * @param {Transform} [options.transform] affine transformation matrix
-     * @param {Number} [options.opacity]
-     * @param {Array.Number} [options.origin] origin adjustment
-     * @param {Array.Number} [options.size] size to apply to descendants
+     * @param {Object} options overrides of default options
+     * @param {Transform} options.transform affine transformation matrix
+     * @param {Number} options.opacity
+     * @param {Array.Number} options.origin origin adjustment
+     * @param {Array.Number} options.size size to apply to descendants
      */
     function Modifier(options) {
         this._transformGetter = null;

--- a/src/core/Surface.js
+++ b/src/core/Surface.js
@@ -11,6 +11,7 @@ define(function(require, exports, module) {
     var ElementOutput = require('./ElementOutput');
 
     /**
+     *
      * A base class for viewable content and event
      *   targets inside a Famo.us application, containing a renderable document
      *   fragment. Like an HTML div, it can accept internal markup,
@@ -19,12 +20,12 @@ define(function(require, exports, module) {
      * @class Surface
      * @constructor
      *
-     * @param {Object} [options] default option overrides
-     * @param {Array.Number} [options.size] [width, height] in pixels
-     * @param {Array.string} [options.classes] CSS classes to set on target div
-     * @param {Array} [options.properties] string dictionary of CSS properties to set on target div
-     * @param {Array} [options.attributes] string dictionary of HTML attributes to set on target div
-     * @param {string} [options.content] inner (HTML) content of surface
+     * @param {Object} options default option overrides
+     * @param {Array.Number} options.size [width, height] in pixels
+     * @param {Array.string} options.classes CSS classes to set on target div
+     * @param {Array} options.properties string dictionary of CSS properties to set on target div
+     * @param {Array} options.attributes string dictionary of HTML attributes to set on target div
+     * @param {string} options.content inner (HTML) content of surface
      */
     function Surface(options) {
         ElementOutput.call(this);
@@ -221,7 +222,7 @@ define(function(require, exports, module) {
      *
      * @method setOptions
      * @chainable
-     * @param {Object} [options] overrides for default options.  See constructor.
+     * @param {Object} options overrides for default options.  See constructor.
      */
     Surface.prototype.setOptions = function setOptions(options) {
         if (options.size) this.setSize(options.size);

--- a/src/core/ViewSequence.js
+++ b/src/core/ViewSequence.js
@@ -18,10 +18,10 @@ define(function(require, exports, module) {
      *
      * @constructor
      * @param {Object|Array} options Options object, or content array.
-     * @param {Number} [options.index] starting index.
-     * @param {Number} [options.array] Array of elements to populate the ViewSequence
-     * @param {Object} [options._] Optional backing store (internal
-     * @param {Boolean} [options.loop] Whether to wrap when accessing elements just past the end
+     * @param {Number} options.index starting index.
+     * @param {Number} options.array Array of elements to populate the ViewSequence
+     * @param {Object} options._ Optional backing store (internal
+     * @param {Boolean} options.loop Whether to wrap when accessing elements just past the end
      *   (or beginning) of the sequence.
      */
     function ViewSequence(options) {

--- a/src/inputs/PinchSync.js
+++ b/src/inputs/PinchSync.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
      * @extends TwoFingerSync
      * @constructor
      * @param {Object} options default options overrides
-     * @param {Number} [options.scale] scale velocity by this factor
+     * @param {Number} options.scale scale velocity by this factor
      */
     function PinchSync(options) {
         TwoFingerSync.call(this);
@@ -87,8 +87,8 @@ define(function(require, exports, module) {
      *
      * @method setOptions
      *
-     * @param {Object} [options] overrides of default options
-     * @param {Number} [options.scale] scale velocity by this factor
+     * @param {Object} options overrides of default options
+     * @param {Number} options.scale scale velocity by this factor
      */
     PinchSync.prototype.setOptions = function setOptions(options) {
         return this._optionsManager.setOptions(options);

--- a/src/inputs/RotateSync.js
+++ b/src/inputs/RotateSync.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
      * @extends TwoFingerSync
      * @constructor
      * @param {Object} options default options overrides
-     * @param {Number} [options.scale] scale velocity by this factor
+     * @param {Number} options.scale scale velocity by this factor
      */
     function RotateSync(options) {
         TwoFingerSync.call(this);
@@ -88,8 +88,8 @@ define(function(require, exports, module) {
      *
      * @method setOptions
      *
-     * @param {Object} [options] overrides of default options
-     * @param {Number} [options.scale] scale velocity by this factor
+     * @param {Object} options overrides of default options
+     * @param {Number} options.scale scale velocity by this factor
      */
     RotateSync.prototype.setOptions = function setOptions(options) {
         return this._optionsManager.setOptions(options);

--- a/src/inputs/ScaleSync.js
+++ b/src/inputs/ScaleSync.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
      * @extends TwoFingerSync
      * @constructor
      * @param {Object} options default options overrides
-     * @param {Number} [options.scale] scale velocity by this factor
+     * @param {Number} options.scale scale velocity by this factor
      */
     function ScaleSync(options) {
         TwoFingerSync.call(this);
@@ -95,8 +95,8 @@ define(function(require, exports, module) {
      *
      * @method setOptions
      *
-     * @param {Object} [options] overrides of default options
-     * @param {Number} [options.scale] scale velocity by this factor
+     * @param {Object} options overrides of default options
+     * @param {Number} options.scale scale velocity by this factor
      */
     ScaleSync.prototype.setOptions = function setOptions(options) {
         return this._optionsManager.setOptions(options);

--- a/src/inputs/ScrollSync.js
+++ b/src/inputs/ScrollSync.js
@@ -23,13 +23,13 @@ define(function(require, exports, module) {
      *
      * @class ScrollSync
      * @constructor
-     * @param {Object} [options] overrides of default options
-     * @param {Number} [options.direction] Pay attention to x changes (ScrollSync.DIRECTION_X),
+     * @param {Object} options overrides of default options
+     * @param {Number} options.direction Pay attention to x changes (ScrollSync.DIRECTION_X),
      *   y changes (ScrollSync.DIRECTION_Y) or both (undefined)
-     * @param {Number} [options.minimumEndSpeed] End speed calculation floors at this number, in pixels per ms
-     * @param {boolean} [options.rails] whether to snap position calculations to nearest axis
-     * @param {Number | Array.Number} [options.scale] scale outputs in by scalar or pair of scalars
-     * @param {Number} [options.stallTime] reset time for velocity calculation in ms
+     * @param {Number} options.minimumEndSpeed End speed calculation floors at this number, in pixels per ms
+     * @param {boolean} options.rails whether to snap position calculations to nearest axis
+     * @param {Number | Array.Number} options.scale scale outputs in by scalar or pair of scalars
+     * @param {Number} options.stallTime reset time for velocity calculation in ms
      */
     function ScrollSync(options) {
         this.options = Object.create(ScrollSync.DEFAULT_OPTIONS);
@@ -181,13 +181,13 @@ define(function(require, exports, module) {
      *
      * @method setOptions
      *
-     * @param {Object} [options] overrides of default options
-     * @param {Number} [options.minimimEndSpeed] If final velocity smaller than this, round down to 0.
-     * @param {Number} [options.stallTime] ms of non-motion before 'end' emitted
-     * @param {Number} [options.rails] whether to constrain to nearest axis.
-     * @param {Number} [options.direction] ScrollSync.DIRECTION_X, DIRECTION_Y -
+     * @param {Object} options overrides of default options
+     * @param {Number} options.minimimEndSpeed If final velocity smaller than this, round down to 0.
+     * @param {Number} options.stallTime ms of non-motion before 'end' emitted
+     * @param {Number} options.rails whether to constrain to nearest axis.
+     * @param {Number} options.direction ScrollSync.DIRECTION_X, DIRECTION_Y -
      *    pay attention to one specific direction.
-     * @param {Number} [options.scale] constant factor to scale velocity output
+     * @param {Number} options.scale constant factor to scale velocity output
      */
     ScrollSync.prototype.setOptions = function setOptions(options) {
         return this._optionsManager.setOptions(options);

--- a/src/modifiers/Draggable.js
+++ b/src/modifiers/Draggable.js
@@ -23,13 +23,13 @@ define(function(require, exports, module) {
      *   Emits events 'start', 'update', 'end'.
      * @class Draggable
      * @constructor
-     * @param {Object} [options] options configuration object.
-     * @param {Number} [options.snapX] grid width for snapping during drag
-     * @param {Number} [options.snapY] grid height for snapping during drag
-     * @param {Array.Number} [options.xRange] maxmimum [negative, positive] x displacement from start of drag
-     * @param {Array.Number} [options.yRange] maxmimum [negative, positive] y displacement from start of drag
-     * @param {Number} [options.scale] one pixel of input motion translates to this many pixels of output drag motion
-     * @param {Number} [options.projection] User should set to Draggable._direction.x or
+     * @param {Object} options options configuration object.
+     * @param {Number} options.snapX grid width for snapping during drag
+     * @param {Number} options.snapY grid height for snapping during drag
+     * @param {Array.Number} options.xRange maxmimum [negative, positive] x displacement from start of drag
+     * @param {Array.Number} options.yRange maxmimum [negative, positive] y displacement from start of drag
+     * @param {Number} options.scale one pixel of input motion translates to this many pixels of output drag motion
+     * @param {Number} options.projection User should set to Draggable._direction.x or
      *    Draggable._direction.y to constrain to one axis.
      *
      */
@@ -140,7 +140,7 @@ define(function(require, exports, module) {
      *
      * @method setOptions
      *
-     * @param {Object} [options] overrides of default options.  See constructor.
+     * @param {Object} options overrides of default options.  See constructor.
      */
     Draggable.prototype.setOptions = function setOptions(options) {
         var currentOptions = this.options;

--- a/src/modifiers/Fader.js
+++ b/src/modifiers/Fader.js
@@ -6,12 +6,12 @@ define(function(require, exports, module) {
      * Modifier that allows you to fade the opacity of affected renderables in and out.
      * @class Fader
      * @constructor
-     * @param {Object} [options] options configuration object.
-     * @param {Boolean} [options.cull=false] Stops returning affected renderables up the tree when they're fully faded when true.
-     * @param {Transition} [options.transition=true] The main transition for showing and hiding.
-     * @param {Transition} [options.pulseInTransition=true] Controls the transition to a pulsed state when the Fader instance's pulse
+     * @param {Object} options options configuration object.
+     * @param {Boolean} options.cull=false Stops returning affected renderables up the tree when they're fully faded when true.
+     * @param {Transition} options.transition=true The main transition for showing and hiding.
+     * @param {Transition} options.pulseInTransition=true Controls the transition to a pulsed state when the Fader instance's pulse
      * method is called.
-     * @param {Transition} [options.pulseOutTransition=true]Controls the transition back from a pulsed state when the Fader instance's pulse
+     * @param {Transition} options.pulseOutTransition=trueControls the transition back from a pulsed state when the Fader instance's pulse
      * method is called.
      *
      */
@@ -37,7 +37,7 @@ define(function(require, exports, module) {
      *
      * @method setOptions
      *
-     * @param {Object} [options] overrides of default options.  See constructor.
+     * @param {Object} options overrides of default options.  See constructor.
      */
     Fader.prototype.setOptions = function setOptions(options) {
         return this._optionsManager.setOptions(options);

--- a/src/modifiers/StateModifier.js
+++ b/src/modifiers/StateModifier.js
@@ -24,13 +24,13 @@ define(function(require, exports, module) {
      *
      * @class StateModifier
      * @constructor
-     * @param {Object} [options] overrides of default options
-     * @param {Transform} [options.transform] affine transformation matrix
-     * @param {Number} [options.opacity]
-     * @param {Array.Number} [options.origin] origin adjustment
-     * @param {Array.Number} [options.align] align adjustment
-     * @param {Array.Number} [options.size] size to apply to descendants
-     * @param {Array.Number} [options.propportions] proportions to apply to descendants
+     * @param {Object} options overrides of default options
+     * @param {Transform} options.transform affine transformation matrix
+     * @param {Number} options.opacity
+     * @param {Array.Number} options.origin origin adjustment
+     * @param {Array.Number} options.align align adjustment
+     * @param {Array.Number} options.size size to apply to descendants
+     * @param {Array.Number} options.propportions proportions to apply to descendants
      */
     function StateModifier(options) {
         this._transformState = new TransitionableTransform(Transform.identity);

--- a/src/physics/constraints/Collision.js
+++ b/src/physics/constraints/Collision.js
@@ -17,10 +17,10 @@ define(function(require, exports, module) {
      *  @class Collision
      *  @constructor
      *  @extends Constraint
-     *  @param {Options} [options] An object of configurable options.
-     *  @param {Number} [options.restitution] The energy ratio lost in a collision (0 = stick, 1 = elastic) Range : [0, 1]
-     *  @param {Number} [options.drift] Baumgarte stabilization parameter. Makes constraints "loosely" (0) or "tightly" (1) enforced. Range : [0, 1]
-     *  @param {Number} [options.slop] Amount of penetration in pixels to ignore before collision event triggers
+     *  @param {Options} options An object of configurable options.
+     *  @param {Number} options.restitution The energy ratio lost in a collision (0 = stick, 1 = elastic) Range : [0, 1]
+     *  @param {Number} options.drift Baumgarte stabilization parameter. Makes constraints "loosely" (0) or "tightly" (1) enforced. Range : [0, 1]
+     *  @param {Number} options.slop Amount of penetration in pixels to ignore before collision event triggers
      *
      */
     function Collision(options) {

--- a/src/physics/constraints/Curve.js
+++ b/src/physics/constraints/Curve.js
@@ -21,11 +21,11 @@ define(function(require, exports, module) {
      *  @class Curve
      *  @constructor
      *  @extends Constraint
-     *  @param {Options} [options] An object of configurable options.
-     *  @param {Function} [options.equation] An implicitly defined surface f(x,y,z) = 0 that body is constrained to e.g. function(x,y,z) { x*x + y*y - r*r } corresponds to a circle of radius r pixels
-     *  @param {Function} [options.plane] An implicitly defined second surface that the body is constrained to
-     *  @param {Number} [options.period] The spring-like reaction when the constraint is violated
-     *  @param {Number} [options.number] The damping-like reaction when the constraint is violated
+     *  @param {Options} options An object of configurable options.
+     *  @param {Function} options.equation An implicitly defined surface f(x,y,z) = 0 that body is constrained to e.g. function(x,y,z) { x*x + y*y - r*r } corresponds to a circle of radius r pixels
+     *  @param {Function} options.plane An implicitly defined second surface that the body is constrained to
+     *  @param {Number} options.period The spring-like reaction when the constraint is violated
+     *  @param {Number} options.number The damping-like reaction when the constraint is violated
      */
     function Curve(options) {
         this.options = Object.create(Curve.DEFAULT_OPTIONS);

--- a/src/physics/constraints/Distance.js
+++ b/src/physics/constraints/Distance.js
@@ -19,12 +19,12 @@ define(function(require, exports, module) {
      *  @class Distance
      *  @constructor
      *  @extends Constraint
-     *  @param {Options} [options] An object of configurable options.
-     *  @param {Array} [options.anchor] The location of the anchor
-     *  @param {Number} [options.length] The amount of distance from the anchor the constraint should enforce
-     *  @param {Number} [options.minLength] The minimum distance before the constraint is activated. Use this property for a "rope" effect.
-     *  @param {Number} [options.period] The spring-like reaction when the constraint is broken.
-     *  @param {Number} [options.dampingRatio] The damping-like reaction when the constraint is broken.
+     *  @param {Options} options An object of configurable options.
+     *  @param {Array} options.anchor The location of the anchor
+     *  @param {Number} options.length The amount of distance from the anchor the constraint should enforce
+     *  @param {Number} options.minLength The minimum distance before the constraint is activated. Use this property for a "rope" effect.
+     *  @param {Number} options.period The spring-like reaction when the constraint is broken.
+     *  @param {Number} options.dampingRatio The damping-like reaction when the constraint is broken.
      *
      */
     function Distance(options) {

--- a/src/physics/constraints/Snap.js
+++ b/src/physics/constraints/Snap.js
@@ -21,11 +21,11 @@ define(function(require, exports, module) {
      *  @class Snap
      *  @constructor
      *  @extends Constraint
-     *  @param {Options} [options] An object of configurable options.
-     *  @param {Number} [options.period] The amount of time in milliseconds taken for one complete oscillation when there is no damping. Range : [150, Infinity]
-     *  @param {Number} [options.dampingRatio] Additional damping of the spring. Range : [0, 1]. At 0 this spring will still be damped, at 1 the spring will be critically damped (the spring will never oscillate)
-     *  @param {Number} [options.length] The rest length of the spring. Range: [0, Infinity].
-     *  @param {Array} [options.anchor] The location of the spring's anchor, if not another physics body.
+     *  @param {Options} options An object of configurable options.
+     *  @param {Number} options.period The amount of time in milliseconds taken for one complete oscillation when there is no damping. Range : [150, Infinity]
+     *  @param {Number} options.dampingRatio Additional damping of the spring. Range : [0, 1]. At 0 this spring will still be damped, at 1 the spring will be critically damped (the spring will never oscillate)
+     *  @param {Number} options.length The rest length of the spring. Range: [0, Infinity].
+     *  @param {Array} options.anchor The location of the spring's anchor, if not another physics body.
      *
      */
     function Snap(options) {

--- a/src/physics/constraints/Surface.js
+++ b/src/physics/constraints/Surface.js
@@ -18,10 +18,10 @@ define(function(require, exports, module) {
      *  @class Surface
      *  @constructor
      *  @extends Constraint
-     *  @param {Options} [options] An object of configurable options.
-     *  @param {Function} [options.equation] An implicitly defined surface f(x,y,z) = 0 that body is constrained to e.g. function(x,y,z) { x*x + y*y + z*z - r*r } corresponds to a sphere of radius r pixels.
-     *  @param {Number} [options.period] The spring-like reaction when the constraint is violated.
-     *  @param {Number} [options.dampingRatio] The damping-like reaction when the constraint is violated.
+     *  @param {Options} options An object of configurable options.
+     *  @param {Function} options.equation An implicitly defined surface f(x,y,z) = 0 that body is constrained to e.g. function(x,y,z) { x*x + y*y + z*z - r*r } corresponds to a sphere of radius r pixels.
+     *  @param {Number} options.period The spring-like reaction when the constraint is violated.
+     *  @param {Number} options.dampingRatio The damping-like reaction when the constraint is violated.
      */
     function Surface(options) {
         this.options = Object.create(Surface.DEFAULT_OPTIONS);

--- a/src/physics/constraints/Wall.js
+++ b/src/physics/constraints/Wall.js
@@ -32,13 +32,13 @@ define(function(require, exports, module) {
      *  @class Wall
      *  @constructor
      *  @extends Constraint
-     *  @param {Options} [options] An object of configurable options.
-     *  @param {Number} [options.restitution] The energy ratio lost in a collision (0 = stick, 1 = elastic). Range : [0, 1]
-     *  @param {Number} [options.drift] Baumgarte stabilization parameter. Makes constraints "loosely" (0) or "tightly" (1) enforced. Range : [0, 1]
-     *  @param {Number} [options.slop] Amount of penetration in pixels to ignore before collision event triggers.
-     *  @param {Array} [options.normal] The normal direction to the wall.
-     *  @param {Number} [options.distance] The distance from the origin that the wall is placed.
-     *  @param {onContact} [options.onContact] How to handle collision against the wall.
+     *  @param {Options} options An object of configurable options.
+     *  @param {Number} options.restitution The energy ratio lost in a collision (0 = stick, 1 = elastic). Range : [0, 1]
+     *  @param {Number} options.drift Baumgarte stabilization parameter. Makes constraints "loosely" (0) or "tightly" (1) enforced. Range : [0, 1]
+     *  @param {Number} options.slop Amount of penetration in pixels to ignore before collision event triggers.
+     *  @param {Array} options.normal The normal direction to the wall.
+     *  @param {Number} options.distance The distance from the origin that the wall is placed.
+     *  @param {onContact} options.onContact How to handle collision against the wall.
      *
      */
     function Wall(options) {

--- a/src/physics/constraints/Walls.js
+++ b/src/physics/constraints/Walls.js
@@ -21,14 +21,14 @@ define(function(require, exports, module) {
      *  @constructor
      *  @extends Constraint
      *  @uses Wall
-     *  @param {Options} [options] An object of configurable options.
-     *  @param {Array} [options.sides] An array of sides e.g., [Walls.LEFT, Walls.TOP]
-     *  @param {Array} [options.size] The size of the bounding box of the walls.
-     *  @param {Array} [options.origin] The center of the wall relative to the size.
-     *  @param {Array} [options.drift] Baumgarte stabilization parameter. Makes constraints "loosely" (0) or "tightly" (1) enforced. Range : [0, 1]
-     *  @param {Array} [options.slop] Amount of penetration in pixels to ignore before collision event triggers.
-     *  @param {Array} [options.restitution] The energy ratio lost in a collision (0 = stick, 1 = elastic) The energy ratio lost in a collision (0 = stick, 1 = elastic)
-     *  @param {Array} [options.onContact] How to handle collision against the wall.
+     *  @param {Options} options An object of configurable options.
+     *  @param {Array} options.sides An array of sides e.g., [Walls.LEFT, Walls.TOP]
+     *  @param {Array} options.size The size of the bounding box of the walls.
+     *  @param {Array} options.origin The center of the wall relative to the size.
+     *  @param {Array} options.drift Baumgarte stabilization parameter. Makes constraints "loosely" (0) or "tightly" (1) enforced. Range : [0, 1]
+     *  @param {Array} options.slop Amount of penetration in pixels to ignore before collision event triggers.
+     *  @param {Array} options.restitution The energy ratio lost in a collision (0 = stick, 1 = elastic) The energy ratio lost in a collision (0 = stick, 1 = elastic)
+     *  @param {Array} options.onContact How to handle collision against the wall.
      */
     function Walls(options) {
         this.options = Object.create(Walls.DEFAULT_OPTIONS);

--- a/src/surfaces/CanvasSurface.js
+++ b/src/surfaces/CanvasSurface.js
@@ -17,8 +17,8 @@ define(function(require, exports, module) {
      * @class CanvasSurface
      * @extends Surface
      * @constructor
-     * @param {Object} [options] overrides of default options
-     * @param {Array.Number} [options.canvasSize] [width, height] for document element
+     * @param {Object} options overrides of default options
+     * @param {Array.Number} options.canvasSize [width, height] for document element
      */
     function CanvasSurface(options) {
         if (options && options.canvasSize) this._canvasSize = options.canvasSize;

--- a/src/surfaces/ContainerSurface.js
+++ b/src/surfaces/ContainerSurface.js
@@ -29,10 +29,10 @@ define(function(require, exports, module) {
      * @class ContainerSurface
      * @extends Surface
      * @constructor
-     * @param {Array.Number} [options.size] [width, height] in pixels
-     * @param {Array.string} [options.classes] CSS classes to set on all inner content
-     * @param {Array} [options.properties] string dictionary of HTML attributes to set on target div
-     * @param {string} [options.content] inner (HTML) content of surface (should not be used)
+     * @param {Array.Number} options.size [width, height] in pixels
+     * @param {Array.string} options.classes CSS classes to set on all inner content
+     * @param {Array} options.properties string dictionary of HTML attributes to set on target div
+     * @param {string} options.content inner (HTML) content of surface (should not be used)
      */
     function ContainerSurface(options) {
         Surface.call(this, options);

--- a/src/surfaces/ImageSurface.js
+++ b/src/surfaces/ImageSurface.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
      *
      * @extends Surface
      * @constructor
-     * @param {Object} [options] overrides of default options
+     * @param {Object} options overrides of default options
      */
     function ImageSurface(options) {
         this._imageUrl = undefined;

--- a/src/surfaces/InputSurface.js
+++ b/src/surfaces/InputSurface.js
@@ -17,10 +17,10 @@ define(function(require, exports, module) {
      * @class InputSurface
      * @extends Surface
      * @constructor
-     * @param {Object} [options] overrides of default options
-     * @param {string} [options.placeholder] placeholder text hint that describes the expected value of an <input> element
-     * @param {string} [options.type] specifies the type of element to display (e.g. 'datetime', 'text', 'button', etc.)
-     * @param {string} [options.value] value of text
+     * @param {Object} options overrides of default options
+     * @param {string} options.placeholder placeholder text hint that describes the expected value of an <input> element
+     * @param {string} options.type specifies the type of element to display (e.g. 'datetime', 'text', 'button', etc.)
+     * @param {string} options.value value of text
      */
     function InputSurface(options) {
         this._placeholder = options.placeholder || '';

--- a/src/surfaces/TextareaSurface.js
+++ b/src/surfaces/TextareaSurface.js
@@ -17,13 +17,13 @@ define(function(require, exports, module) {
      * @class TextareaSurface
      * @extends Surface
      * @constructor
-     * @param {Object} [options] overrides of default options
-     * @param {string} [options.placeholder] placeholder text hint that describes the expected value of an textarea element
-     * @param {string} [options.value] value of text
-     * @param {string} [options.name] specifies the name of textarea
-     * @param {string} [options.wrap] specify 'hard' or 'soft' wrap for textarea
-     * @param {number} [options.cols] number of columns in textarea
-     * @param {number} [options.rows] number of rows in textarea
+     * @param {Object} options overrides of default options
+     * @param {string} options.placeholder placeholder text hint that describes the expected value of an textarea element
+     * @param {string} options.value value of text
+     * @param {string} options.name specifies the name of textarea
+     * @param {string} options.wrap specify 'hard' or 'soft' wrap for textarea
+     * @param {number} options.cols number of columns in textarea
+     * @param {number} options.rows number of rows in textarea
      */
     function TextareaSurface(options) {
         this._placeholder = options.placeholder || '';

--- a/src/surfaces/VideoSurface.js
+++ b/src/surfaces/VideoSurface.js
@@ -20,12 +20,12 @@ define(function(require, exports, module) {
      * @class VideoSurface
      * @extends Surface
      * @constructor
-     * @param {Object} [options] default option overrides
-     * @param {Array.Number} [options.size] [width, height] in pixels
-     * @param {Array.string} [options.classes] CSS classes to set on inner content
-     * @param {Array} [options.properties] string dictionary of HTML attributes to set on target div
-     * @param {String} [options.src] videoUrl URL
-     * @param {boolean} [options.autoplay] autoplay
+     * @param {Object} options default option overrides
+     * @param {Array.Number} options.size [width, height] in pixels
+     * @param {Array.string} options.classes CSS classes to set on inner content
+     * @param {Array} options.properties string dictionary of HTML attributes to set on target div
+     * @param {String} options.src videoUrl URL
+     * @param {boolean} options.autoplay autoplay
      */
     function VideoSurface(options) {
         Surface.apply(this, arguments);
@@ -49,8 +49,8 @@ define(function(require, exports, module) {
      *
      * @method setOptions
      *
-     * @param {Object} [options] overrides of default options
-     * @param {Boolean} [options.autoplay] HTML autoplay
+     * @param {Object} options overrides of default options
+     * @param {Boolean} options.autoplay HTML autoplay
      */
     VideoSurface.prototype.setOptions = function setOptions(options) {
         if (options.size) this.setSize(options.size);

--- a/src/transitions/TweenTransition.js
+++ b/src/transitions/TweenTransition.js
@@ -200,9 +200,9 @@ define(function(require, exports, module) {
      *
      *
      * @param {Object} options options object
-     * @param {Object} [options.curve] function mapping [0,1] to [0,1] or identifier
-     * @param {Number} [options.duration] duration in ms
-     * @param {Number} [options.speed] speed in pixels per ms
+     * @param {Object} options.curve function mapping [0,1] to [0,1] or identifier
+     * @param {Number} options.duration duration in ms
+     * @param {Number} options.speed speed in pixels per ms
      */
     TweenTransition.prototype.setOptions = function setOptions(options) {
         if (options.curve !== undefined) this.options.curve = options.curve;

--- a/src/views/ContextualView.js
+++ b/src/views/ContextualView.js
@@ -20,7 +20,7 @@ define(function(require, exports, module) {
      *   and an output EventHandler. Meant to be extended by the developer.
      * @class ContextualView
      * @constructor
-     * @param {Options} [options] An object of configurable options.
+     * @param {Options} options An object of configurable options.
      */
     function ContextualView(options) {
         this.options = Object.create(this.constructor.DEFAULT_OPTIONS || ContextualView.DEFAULT_OPTIONS);

--- a/src/views/Deck.js
+++ b/src/views/Deck.js
@@ -25,13 +25,13 @@ define(function(require, exports, module) {
      * @constructor
      * @extends SequentialLayout
      *
-     * @param {Options} [options] An object of configurable options
-     * @param {Transition} [options.transition={duration: 500, curve: 'easeOutBounce'}
+     * @param {Options} options An object of configurable options
+     * @param {Transition} options.transition={duration: 500, curve: 'easeOutBounce'}
      *   The transition that executes upon opening or closing your deck instance.
-     * @param {Number} [stackRotation=0] The amount of rotation applied to the propogation
+     * @param {Number} [stackRotation=0 The amount of rotation applied to the propogation
      *   of the Deck instance's stack of renderables.
-     * @param {Object} [options.transition] A transition object for changing between states.
-     * @param {Number} [options.direction] axis of expansion (Utility.Direction.X or .Y)
+     * @param {Object} options.transition A transition object for changing between states.
+     * @param {Number} options.direction axis of expansion (Utility.Direction.X or .Y)
      */
     function Deck(options) {
         SequentialLayout.apply(this, arguments);

--- a/src/views/EdgeSwapper.js
+++ b/src/views/EdgeSwapper.js
@@ -18,7 +18,7 @@ define(function(require, exports, module) {
      * Container which handles swapping renderables from the edge of its parent context.
      * @class EdgeSwapper
      * @constructor
-     * @param {Options} [options] An object of configurable options.
+     * @param {Options} options An object of configurable options.
      *   Takes the same options as RenderController.
      * @uses RenderController
      */

--- a/src/views/FlexibleLayout.js
+++ b/src/views/FlexibleLayout.js
@@ -20,10 +20,10 @@ define(function(require, exports, module) {
      *   out vertically or horizontally.
      * @class FlexibleLayout
      * @constructor
-     * @param {Options} [options] An object of configurable options.
-     * @param {Number} [options.direction=0] Direction the FlexibleLayout instance should lay out renderables.
-     * @param {Transition} [options.transition=false] The transiton that controls the FlexibleLayout instance's reflow.
-     * @param {Ratios} [options.ratios=[]] The proportions for the renderables to maintain
+     * @param {Options} options An object of configurable options.
+     * @param {Number} options.direction=0 Direction the FlexibleLayout instance should lay out renderables.
+     * @param {Transition} options.transition=false The transiton that controls the FlexibleLayout instance's reflow.
+     * @param {Ratios} options.ratios=[] The proportions for the renderables to maintain
      */
     function FlexibleLayout(options) {
         this.options = Object.create(FlexibleLayout.DEFAULT_OPTIONS);

--- a/src/views/Flipper.js
+++ b/src/views/Flipper.js
@@ -20,9 +20,9 @@ define(function(require, exports, module) {
      *
      * @class Flipper
      * @constructor
-     * @param {Options} [options] An object of options.
-     * @param {Transition} [options.transition=true] The transition executed when flipping your Flipper instance.
-     * @param {Direction} [options.direction=Flipper.DIRECTION_X] Direction specifies the axis of rotation.
+     * @param {Options} options An object of options.
+     * @param {Transition} options.transition=true The transition executed when flipping your Flipper instance.
+     * @param {Direction} options.direction=Flipper.DIRECTION_X Direction specifies the axis of rotation.
      */
     function Flipper(options) {
         this.options = Object.create(Flipper.DEFAULT_OPTIONS);

--- a/src/views/GridLayout.js
+++ b/src/views/GridLayout.js
@@ -25,12 +25,12 @@ define(function(require, exports, module) {
      *   dimensions so that items of cellSize will fit.
      * @class GridLayout
      * @constructor
-     * @param {Options} [options] An object of configurable options.
-     * @param {Array.Number} [options.dimensions=[1, 1]] A two value array which specifies the amount of columns
+     * @param {Options} options An object of configurable options.
+     * @param {Array.Number} options.dimensions=[1, 1] A two value array which specifies the amount of columns
      * and rows in your Gridlayout instance.
-     * @param {Array.Number} [options.gutterSize=[0, 0]] A two-value array which specifies size of the
+     * @param {Array.Number} options.gutterSize=[0, 0] A two-value array which specifies size of the
      * horizontal and vertical gutters between items in the grid layout.
-     * @param {Transition} [options.transition=false] The transiton that controls the Gridlayout instance's reflow.
+     * @param {Transition} options.transition=false The transiton that controls the Gridlayout instance's reflow.
      */
     function GridLayout(options) {
         this.options = Object.create(GridLayout.DEFAULT_OPTIONS);

--- a/src/views/HeaderFooterLayout.js
+++ b/src/views/HeaderFooterLayout.js
@@ -18,13 +18,13 @@ define(function(require, exports, module) {
       and a content area of flexible size.
      * @class HeaderFooterLayout
      * @constructor
-     * @param {Options} [options] An object of configurable options.
-     * @param {Number} [options.direction=HeaderFooterLayout.DIRECTION_Y] A direction of HeaderFooterLayout.DIRECTION_X
+     * @param {Options} options An object of configurable options.
+     * @param {Number} options.direction=HeaderFooterLayout.DIRECTION_Y A direction of HeaderFooterLayout.DIRECTION_X
      * lays your HeaderFooterLayout instance horizontally, and a direction of HeaderFooterLayout.DIRECTION_Y
      * lays it out vertically.
-     * @param {Number} [options.headerSize=undefined]  The amount of pixels allocated to the header node
+     * @param {Number} options.headerSize=undefined  The amount of pixels allocated to the header node
      * in the HeaderFooterLayout instance's direction.
-     * @param {Number} [options.footerSize=undefined] The amount of pixels allocated to the footer node
+     * @param {Number} options.footerSize=undefined The amount of pixels allocated to the footer node
      * in the HeaderFooterLayout instance's direction.
      */
     function HeaderFooterLayout(options) {

--- a/src/views/Lightbox.js
+++ b/src/views/Lightbox.js
@@ -13,32 +13,32 @@ define(function(require, exports, module) {
      *
      * @class Lightbox
      * @constructor
-     * @param {Options} [options] An object of configurable options.
-     * @param {Transform} [options.inTransform] The transform at the start of transitioning in a shown renderable.
-     * @param {Transform} [options.outTransform] The transform at the end of transitioning out a renderable.
-     * @param {Transform} [options.showTransform] The transform applied to your shown renderable in its state of equilibrium.
-     * @param {Number} [options.inOpacity] A number between one and zero that defines the state of a shown renderables opacity upon initially
+     * @param {Options} options An object of configurable options.
+     * @param {Transform} options.inTransform The transform at the start of transitioning in a shown renderable.
+     * @param {Transform} options.outTransform The transform at the end of transitioning out a renderable.
+     * @param {Transform} options.showTransform The transform applied to your shown renderable in its state of equilibrium.
+     * @param {Number} options.inOpacity A number between one and zero that defines the state of a shown renderables opacity upon initially
      * being transitioned in.
-     * @param {Number} [options.outOpacity] A number between one and zero that defines the state of a shown renderables opacity upon being
+     * @param {Number} options.outOpacity A number between one and zero that defines the state of a shown renderables opacity upon being
      * fully transitioned out.
-     * @param {Number} [options.showOpacity] A number between one and zero that defines the state of a shown renderables opacity
+     * @param {Number} options.showOpacity A number between one and zero that defines the state of a shown renderables opacity
      * once succesfully transitioned in.
-     * @param {Array<Number>} [options.inOrigin] A two value array of numbers between one and zero that defines the state of a shown renderables
+     * @param {Array<Number>} options.inOrigin A two value array of numbers between one and zero that defines the state of a shown renderables
      * origin upon intially being transitioned in.
-     * @param {Array<Number>} [options.outOrigin] A two value array of numbers between one and zero that defines the state of a shown renderable
+     * @param {Array<Number>} options.outOrigin A two value array of numbers between one and zero that defines the state of a shown renderable
      * origin once fully hidden.
-     * @param {Array<Number>} [options.showOrigin] A two value array of numbers between one and zero that defines the state of a shown renderables
+     * @param {Array<Number>} options.showOrigin A two value array of numbers between one and zero that defines the state of a shown renderables
      * origin upon succesfully being shown.
-     * @param {Array<Number>} [options.inAlign] A two value array of numbers between one and zero that defines the state of a shown renderables
+     * @param {Array<Number>} options.inAlign A two value array of numbers between one and zero that defines the state of a shown renderables
      * align upon intially being transitioned in.
-     * @param {Array<Number>} [options.outAlign] A two value array of numbers between one and zero that defines the state of a shown renderable
+     * @param {Array<Number>} options.outAlign A two value array of numbers between one and zero that defines the state of a shown renderable
      * align once fully hidden.
-     * @param {Array<Number>} [options.showAlign] A two value array of numbers between one and zero that defines the state of a shown renderables
+     * @param {Array<Number>} options.showAlign A two value array of numbers between one and zero that defines the state of a shown renderables
      * align upon succesfully being shown.
-     * @param {Transition} [options.inTransition=true] The transition in charge of showing a renderable.
-     * @param {Transition} [options.outTransition=true]  The transition in charge of removing your previous renderable when
+     * @param {Transition} options.inTransition=true The transition in charge of showing a renderable.
+     * @param {Transition} options.outTransition=true  The transition in charge of removing your previous renderable when
      * you show a new one, or hiding your current renderable.
-     * @param {Boolean} [options.overlap=false] When showing a new renderable, overlap determines if the
+     * @param {Boolean} options.overlap=false When showing a new renderable, overlap determines if the
      *   out transition of the old one executes concurrently with the in transition of the new one,
       *  or synchronously beforehand.
      */

--- a/src/views/RenderController.js
+++ b/src/views/RenderController.js
@@ -18,7 +18,7 @@ define(function(require, exports, module) {
      * A dynamic view that can show or hide different renderables with transitions.
      * @class RenderController
      * @constructor
-     * @param {Options} [options] An object of configurable options.
+     * @param {Options} options An object of configurable options.
      * @param {Transition} [inTransition=true] The transition in charge of showing a renderable.
      * @param {Transition} [outTransition=true]  The transition in charge of removing your previous renderable when
      * you show a new one, or hiding your current renderable.

--- a/src/views/ScrollContainer.js
+++ b/src/views/ScrollContainer.js
@@ -21,9 +21,9 @@ define(function(require, exports, module) {
      * surface.
      * @class ScrollContainer
      * @constructor
-     * @param {Options} [options] An object of configurable options.
-     * @param {Options} [options.container=undefined] Options for the ScrollContainer instance's surface.
-     * @param {Options} [options.scrollview={direction:Utility.Direction.X}]  Options for the ScrollContainer instance's scrollview.
+     * @param {Options} options An object of configurable options.
+     * @param {Options} options.container=undefined Options for the ScrollContainer instance's surface.
+     * @param {Options} options.scrollview={direction:Utility.Direction.X}  Options for the ScrollContainer instance's scrollview.
      */
     function ScrollContainer(options) {
         this.options = Object.create(ScrollContainer.DEFAULT_OPTIONS);

--- a/src/views/Scroller.js
+++ b/src/views/Scroller.js
@@ -14,8 +14,8 @@ define(function(require, exports, module) {
      * @class Scroller
      * @constructor
       * @event error
-     * @param {Options} [options] An object of configurable options.
-     * @param {Number} [options.direction=Utility.Direction.Y] Using the direction helper found in the famous Utility
+     * @param {Options} options An object of configurable options.
+     * @param {Number} options.direction=Utility.Direction.Y Using the direction helper found in the famous Utility
      * module, this option will lay out the Scroller instance's renderables either horizontally
      * (x) or vertically (y). Utility's direction is essentially either zero (X) or one (Y), so feel free
      * to just use integers as well.

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -46,12 +46,12 @@ define(function(require, exports, module) {
      * allow you to scroll through them with mousewheel or touch events.
      * @class Scrollview
      * @constructor
-     * @param {Options} [options] An object of configurable options.
-     * @param {Number} [options.direction=Utility.Direction.Y] Using the direction helper found in the famous Utility
+     * @param {Options} options An object of configurable options.
+     * @param {Number} options.direction=Utility.Direction.Y Using the direction helper found in the famous Utility
      * module, this option will lay out the Scrollview instance's renderables either horizontally
      * (x) or vertically (y). Utility's direction is essentially either zero (X) or one (Y), so feel free
      * to just use integers as well.
-     * @param {Boolean} [options.rails=true] When true, Scrollview's genericSync will only process input in it's primary access.
+     * @param {Boolean} options.rails=true When true, Scrollview's genericSync will only process input in it's primary access.
      * @param {Number} [clipSize=undefined] The size of the area (in pixels) that Scrollview will display content in.
      * @param {Number} [margin=undefined] The size of the area (in pixels) that Scrollview will process renderables' associated calculations in.
      * @param {Number} [friction=0.001] Input resistance proportional to the velocity of the input.

--- a/src/views/SequentialLayout.js
+++ b/src/views/SequentialLayout.js
@@ -18,8 +18,8 @@ define(function(require, exports, module) {
      * SequentialLayout will lay out a collection of renderables sequentially in the specified direction.
      * @class SequentialLayout
      * @constructor
-     * @param {Options} [options] An object of configurable options.
-     * @param {Number} [options.direction=Utility.Direction.Y] Using the direction helper found in the famous Utility
+     * @param {Options} options An object of configurable options.
+     * @param {Number} options.direction=Utility.Direction.Y Using the direction helper found in the famous Utility
      * module, this option will lay out the SequentialLayout instance's renderables either horizontally
      * (x) or vertically (y). Utility's direction is essentially either zero (X) or one (Y), so feel free
      * to just use integers as well.

--- a/src/widgets/NavigationBar.js
+++ b/src/widgets/NavigationBar.js
@@ -22,14 +22,14 @@ define(function(require, exports, module) {
      * @extends View
      * @constructor
      *
-     * @param {object} [options] overrides of default options
-     * @param {Array.number} [options.size=(undefined,0.5)] Size of the navigation bar and it's componenets.
-     * @param {Array.string} [options.backClasses=(back)] CSS Classes attached to back of Navigation.
-     * @param {String} [options.backContent=(&#x25c0;)] Content of the back button.
-     * @param {Array.string} [options.classes=(navigation)] CSS Classes attached to the surfaces.
-     * @param {String} [options.content] Content to pass into title bar.
-     * @param {Array.string} [options.classes=(more)] CSS Classes attached to the More surface.
-     * @param {String} [options.moreContent=(&#x271a;)] Content of the more button.
+     * @param {object} options overrides of default options
+     * @param {Array.number} options.size=(undefined,0.5) Size of the navigation bar and it's componenets.
+     * @param {Array.string} options.backClasses=(back) CSS Classes attached to back of Navigation.
+     * @param {String} options.backContent=(&#x25c0;) Content of the back button.
+     * @param {Array.string} options.classes=(navigation) CSS Classes attached to the surfaces.
+     * @param {String} options.content Content to pass into title bar.
+     * @param {Array.string} options.classes=(more) CSS Classes attached to the More surface.
+     * @param {String} options.moreContent=(&#x271a;) Content of the more button.
      */
     function NavigationBar(options) {
         View.apply(this, arguments);


### PR DESCRIPTION
We need to not have the square braces around options or the doc builder explodes