### PR TITLE
Utility method to clear all entities

### DIFF
--- a/src/core/Entity.js
+++ b/src/core/Entity.js
@@ -68,9 +68,20 @@ define(function(require, exports, module) {
         set(id, null);
     }
 
+    /**
+     * Clears all registered entities from global index
+     *
+     * @private
+     * @method clear
+     */
+    function clear() {
+        entities = [];
+    }
+
     module.exports = {
         register: register,
         unregister: unregister,
+        clear: clear,
         get: get,
         set: set
     };


### PR DESCRIPTION
It would be useful to have a clear method on `Entity`.  The same behavior can be achieved by walking the context tree and `unregister`ing each element.
