### PR TITLE
Add the famous source object to forwarded events

### DIFF
--- a/src/core/ElementOutput.js
+++ b/src/core/ElementOutput.js
@@ -37,6 +37,7 @@ define(function(require, exports, module) {
 
         /** @ignore */
         this.eventForwarder = function eventForwarder(event) {
+            event.famousTarget = this;
             this._eventOutput.emit(event.type, event);
         }.bind(this);
 

--- a/src/inputs/MouseSync.js
+++ b/src/inputs/MouseSync.js
@@ -70,6 +70,7 @@ define(function(require, exports, module) {
             delta    : null,
             position : null,
             velocity : null,
+            target   : null,
             clientX  : 0,
             clientY  : 0,
             offsetX  : 0,
@@ -139,6 +140,7 @@ define(function(require, exports, module) {
         payload.delta = delta;
         payload.position = this._position;
         payload.velocity = velocity;
+        payload.target = event.famousTarget;
         payload.clientX = x;
         payload.clientY = y;
         payload.offsetX = event.offsetX;
@@ -213,6 +215,7 @@ define(function(require, exports, module) {
         payload.delta    = nextDelta;
         payload.position = this._position;
         payload.velocity = nextVel;
+        payload.target   = event.famousTarget;
         payload.clientX  = x;
         payload.clientY  = y;
         payload.offsetX  = event.offsetX;

--- a/src/inputs/PinchSync.js
+++ b/src/inputs/PinchSync.js
@@ -44,6 +44,7 @@ define(function(require, exports, module) {
         this._displacement = 0;
 
         this._eventOutput.emit('start', {
+            target: event.famousTarget,
             count: event.touches.length,
             touches: [this.touchAId, this.touchBId],
             distance: this._dist,
@@ -51,7 +52,7 @@ define(function(require, exports, module) {
         });
     };
 
-    PinchSync.prototype._moveUpdate = function _moveUpdate(diffTime) {
+    PinchSync.prototype._moveUpdate = function _moveUpdate(diffTime, event) {
         var currDist = TwoFingerSync.calculateDistance(this.posA, this.posB);
         var center = TwoFingerSync.calculateCenter(this.posA, this.posB);
 
@@ -65,6 +66,7 @@ define(function(require, exports, module) {
         this._eventOutput.emit('update', {
             delta : delta,
             velocity: velocity,
+            target: event.famousTarget,
             distance: currDist,
             displacement: this._displacement,
             center: center,

--- a/src/inputs/RotateSync.js
+++ b/src/inputs/RotateSync.js
@@ -44,6 +44,7 @@ define(function(require, exports, module) {
         this._previousAngle = TwoFingerSync.calculateAngle(this.posA, this.posB);
         var center = TwoFingerSync.calculateCenter(this.posA, this.posB);
         this._eventOutput.emit('start', {
+            target: event.famousTarget,
             count: event.touches.length,
             angle: this._angle,
             center: center,
@@ -51,7 +52,7 @@ define(function(require, exports, module) {
         });
     };
 
-    RotateSync.prototype._moveUpdate = function _moveUpdate(diffTime) {
+    RotateSync.prototype._moveUpdate = function _moveUpdate(diffTime, event) {
         var scale = this.options.scale;
 
         var currAngle = TwoFingerSync.calculateAngle(this.posA, this.posB);
@@ -65,6 +66,7 @@ define(function(require, exports, module) {
         this._eventOutput.emit('update', {
             delta : diffTheta,
             velocity: velTheta,
+            target: event.famousTarget,
             angle: this._angle,
             center: center,
             touches: [this.touchAId, this.touchBId]

--- a/src/inputs/ScaleSync.js
+++ b/src/inputs/ScaleSync.js
@@ -50,6 +50,7 @@ define(function(require, exports, module) {
         this._scaleFactor = 1;
         this._startDist = TwoFingerSync.calculateDistance(this.posA, this.posB);
         this._eventOutput.emit('start', {
+            target: event.famousTarget,
             count: event.touches.length,
             touches: [this.touchAId, this.touchBId],
             distance: this._startDist,
@@ -58,7 +59,7 @@ define(function(require, exports, module) {
     };
 
     // handles movement of two fingers
-    ScaleSync.prototype._moveUpdate = function _moveUpdate(diffTime) {
+    ScaleSync.prototype._moveUpdate = function _moveUpdate(diffTime, event) {
         var scale = this.options.scale;
 
         var currDist = TwoFingerSync.calculateDistance(this.posA, this.posB);
@@ -72,6 +73,7 @@ define(function(require, exports, module) {
             delta : delta,
             scale: newScaleFactor,
             velocity: veloScale,
+            target: event.famousTarget,
             distance: currDist,
             center : center,
             touches: [this.touchAId, this.touchBId]

--- a/src/inputs/ScrollSync.js
+++ b/src/inputs/ScrollSync.js
@@ -40,6 +40,7 @@ define(function(require, exports, module) {
             delta    : null,
             position : null,
             velocity : null,
+            target   : null,
             slip     : true
         };
 
@@ -95,10 +96,13 @@ define(function(require, exports, module) {
     function _handleMove(event) {
         if (this.options.preventDefault) event.preventDefault();
 
+        var payload = this._payload;
+
         if (!this._inProgress) {
             this._inProgress = true;
             this._position = (this.options.direction === undefined) ? [0,0] : 0;
             payload = this._payload;
+            payload.target = event.famousTarget;
             payload.slip = true;
             payload.position = this._position;
             payload.clientX = event.clientX;
@@ -154,10 +158,10 @@ define(function(require, exports, module) {
             this._position[1] += nextDelta[1];
         }
 
-        var payload = this._payload;
         payload.delta    = nextDelta;
         payload.velocity = nextVel;
         payload.position = this._position;
+        payload.target   = event.famousTarget;
         payload.slip     = true;
 
         this._eventOutput.emit('update', payload);

--- a/src/inputs/TouchSync.js
+++ b/src/inputs/TouchSync.js
@@ -60,6 +60,7 @@ define(function(require, exports, module) {
             delta    : null,
             position : null,
             velocity : null,
+            target   : null,
             clientX  : undefined,
             clientY  : undefined,
             count    : 0,
@@ -105,6 +106,7 @@ define(function(require, exports, module) {
         payload.delta = delta;
         payload.position = this._position;
         payload.velocity = velocity;
+        payload.target = data.target;
         payload.clientX = data.x;
         payload.clientY = data.y;
         payload.count = data.count;
@@ -175,6 +177,7 @@ define(function(require, exports, module) {
         payload.delta    = nextDelta;
         payload.velocity = nextVel;
         payload.position = this._position;
+        payload.target   = data.target;
         payload.clientX  = data.x;
         payload.clientY  = data.y;
         payload.count    = data.count;

--- a/src/inputs/TouchTracker.js
+++ b/src/inputs/TouchTracker.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
             origin: event.origin,
             timestamp: _now(),
             count: event.touches.length,
-            target: event.famousTarget;
+            target: event.famousTarget,
             history: history
         };
     }

--- a/src/inputs/TouchTracker.js
+++ b/src/inputs/TouchTracker.js
@@ -19,6 +19,7 @@ define(function(require, exports, module) {
             origin: event.origin,
             timestamp: _now(),
             count: event.touches.length,
+            target: event.famousTarget;
             history: history
         };
     }

--- a/src/inputs/TwoFingerSync.js
+++ b/src/inputs/TwoFingerSync.js
@@ -96,7 +96,7 @@ define(function(require, exports, module) {
                 diffTime = this.timestampB - prevTimeB;
             }
         }
-        if (diffTime) this._moveUpdate(diffTime);
+        if (diffTime) this._moveUpdate(diffTime, event);
     };
 
     // private
@@ -107,7 +107,8 @@ define(function(require, exports, module) {
                 if (this.touchAEnabled && this.touchBEnabled) {
                     this._eventOutput.emit('end', {
                         touches : [this.touchAId, this.touchBId],
-                        angle   : this._angle
+                        angle   : this._angle,
+                        target  : event.famousTarget
                     });
                 }
                 this.touchAEnabled = false;


### PR DESCRIPTION
When events are forwarded from DOM elements, it would be very useful to have the corresponding famous element available in the forwarded event.