### PR TITLE
Allow for 'robust' physics computation

### DIFF
--- a/src/physics/PhysicsEngine.js
+++ b/src/physics/PhysicsEngine.js
@@ -460,7 +460,7 @@ define(function(require, exports, module) {
             while (this._buffer > TIMESTEP){
                 _integrate.call(this, TIMESTEP);
                 this._buffer -= TIMESTEP;
-            };
+            }
             _integrate.call(this, this._buffer);
             this._buffer = 0.0;
         }

--- a/src/physics/PhysicsEngine.js
+++ b/src/physics/PhysicsEngine.js
@@ -101,7 +101,7 @@ define(function(require, exports, module) {
      * Options setter
      *
      * @method setOptions
-     * @param opts {Object}
+     * @param options {Object}
      */
     PhysicsEngine.prototype.setOptions = function setOptions(options) {
         this._optionsManager.setOptions(options);


### PR DESCRIPTION
Enable the "robust" implementation of the physics engine.  I guessed at the `TIMESTAMP` parameters and I can almost guarantee that they are wrong.  This is mainly to facilitate discussion.

Note: Not entirely sure what difference this makes... 