### PR TITLE
Optimize engine tick queues

### DIFF
--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -78,8 +78,8 @@ define(function(require, exports, module) {
         var currentTickQueue = nextTickQueue;
         nextTickQueue = undefined;
 
-        var i = 0,
-            l = 0;
+        var i = 0;
+        var l = 0;
 
         // empty the queue
         if (currentTickQueue) {

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -78,7 +78,8 @@ define(function(require, exports, module) {
         var currentTickQueue = nextTickQueue;
         nextTickQueue = undefined;
 
-        var i = 0, l = 0;
+        var i = 0,
+            l = 0;
 
         // empty the queue
         if (currentTickQueue) {

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -88,19 +88,16 @@ define(function(require, exports, module) {
         }
 
         if (deferQueue) {
-            var queued = 0,
-                l = deferQueue.length;
+            var queued = 0;
+            l = deferQueue.length;
 
             // limit total execution time for deferrable functions
             while (queued < l && Date.now() - currentTime < MAX_DEFER_FRAME_TIME) {
                 deferQueue[queued++]();
             }
-            if (queued === l) {
-                deferQueue = undefined;
-            }
-            else {
-                deferQueue.splice(0, queued);
-            }
+
+            if (queued === l) deferQueue = undefined;
+            else deferQueue.splice(0, queued);
         }
 
         for (i = 0, l = contexts.length; i < l; i++) {

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -78,21 +78,24 @@ define(function(require, exports, module) {
         var currentTickQueue = nextTickQueue;
         nextTickQueue = undefined;
 
+        var i = 0, l = 0;
+
         // empty the queue
         if (currentTickQueue) {
-            for (var t = 0, l = currentTickQueue.length; t < l; t++) {
+            for (l = currentTickQueue.length; i < l; i++) {
                 currentTickQueue[i]();
             }
         }
 
         if (deferQueue) {
-            var queued = 0;
+            var queued = 0,
+                l = deferQueue.length;
 
             // limit total execution time for deferrable functions
-            for (; Date.now() - currentTime < MAX_DEFER_FRAME_TIME; queued++) {
-                deferQueue[queued]();
+            while (queued < l && Date.now() - currentTime < MAX_DEFER_FRAME_TIME) {
+                deferQueue[queued++]();
             }
-            if (queued === deferQueue.length) {
+            if (queued === l) {
                 deferQueue = undefined;
             }
             else {
@@ -100,7 +103,7 @@ define(function(require, exports, module) {
             }
         }
 
-        for (var i = 0; i < contexts.length; i++) {
+        for (i = 0, l = contexts.length; i < l; i++) {
             contexts[i].update();
         }
 


### PR DESCRIPTION
Optimize the critical path of `Engine.step()` and fix bug calling `Engine.nextTick()` from the update of a particle/body.

The goals of this change:
- Reduce the array manipulations
- Only use single dimensional queues
- Only store queues with valid objects
- Consolidate repeated operations
