### PR TITLE
Fix broken Famous demos link. Point link to Famous' Codepen account.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Copyright (c) 2014 Famous Industries, Inc.
 [famous-university]: https://famo.us/university
 [famous-help]: https://famo.us/help
 [famous-docs]: http://famo.us/docs
-[famous-demos]: http://famo.us/demos
+[famous-demos]: http://codepen.io/befamous/
 [famous-angular]: http://famo.us/integrations/angular/
 [famous-angular-starter-kit]: http://code.famo.us/famous-angular/latest/famous-angular-starter-kit.zip?source=repo
 [IRC]: http://webchat.freenode.net/?channels=famous


### PR DESCRIPTION
Currently the famous demo link is broken. I suggest linking to the famous codepen page where users can actually see a variety of demos using famous.