### PR TITLE
Context should initialize itself

### DIFF
--- a/src/core/Context.js
+++ b/src/core/Context.js
@@ -229,12 +229,12 @@ define(function(require, exports, module) {
      *
      *
      * @method removeListener
+     *
      * @param {string} type event type key (for example, 'click')
      * @param {function} handler function object to remove
-     * @return {EventHandler} internal event handler object (for chaining)
      */
     Context.prototype.removeListener = function removeListener(type, handler) {
-        return this._eventOutput.removeListener(type, handler);
+        this._eventOutput.removeListener(type, handler);
     };
 
     /**

--- a/src/core/Context.js
+++ b/src/core/Context.js
@@ -37,7 +37,7 @@ define(function(require, exports, module) {
      * @private
      * @param {Node} container Element in which content will be inserted
      */
-    function Context(container) {
+    function Context(container, appMode) {
         this.container = container;
         this._allocator = new ElementAllocator(container);
 
@@ -62,16 +62,32 @@ define(function(require, exports, module) {
             this.setSize(_getElementSize(this.container));
         }.bind(this));
 
-        this._eventOutput.on('touchmove', function(event) {
-            event.preventDefault();
-        });
-
         /** @ignore */
         this.eventForwarder = function eventForwarder(event) {
             this._eventOutput.emit(event.type, event);
         }.bind(this);
 
         _addEventListeners.call(this, container);
+
+        if (appMode) {
+            initialize.call(this);
+        }
+    }
+
+    /**
+     * Initialize famous for app mode
+     *
+     * @static
+     * @private
+     * @method initialize
+     */
+    function initialize() {
+        // prevent scrolling via browser
+        this.on('touchmove', function(event) {
+            event.preventDefault();
+        }, true);
+
+        this.container.classList.add('famous-root');
     }
 
     //  Attach Famous event handling to document events emanating from container
@@ -217,8 +233,8 @@ define(function(require, exports, module) {
      * @param {string} type event type key (for example, 'click')
      * @param {function(string, Object)} handler callback
      */
-    Context.prototype.on = function on(type, handler) {
-        if (this.container) this.container.addEventListener(type, this.eventForwarder);
+    Context.prototype.on = function on(type, handler, capture) {
+        if (this.container) this.container.addEventListener(type, this.eventForwarder, capture);
         this._eventOutput.on(type, handler);
     };
 

--- a/src/core/Context.js
+++ b/src/core/Context.js
@@ -232,6 +232,7 @@ define(function(require, exports, module) {
      *
      * @param {string} type event type key (for example, 'click')
      * @param {function(string, Object)} handler callback
+     * @param {boolean} capture use capture
      */
     Context.prototype.on = function on(type, handler, capture) {
         if (this.container) this.container.addEventListener(type, this.eventForwarder, capture);

--- a/src/core/Context.js
+++ b/src/core/Context.js
@@ -225,14 +225,16 @@ define(function(require, exports, module) {
 
     /**
      * Unbind an event by type and handler.
-     *   This undoes the work of "on"
+     *   This undoes the work of "on".
+     *
      *
      * @method removeListener
      * @param {string} type event type key (for example, 'click')
-     * @param {function(string, Object)} fn handler
+     * @param {function} handler function object to remove
+     * @return {EventHandler} internal event handler object (for chaining)
      */
-    Context.prototype.removeListener = function removeListener(type, fn) {
-        this._eventOutput.removeListener(type, fn);
+    Context.prototype.removeListener = function removeListener(type, handler) {
+        return this._eventOutput.removeListener(type, handler);
     };
 
     /**

--- a/src/core/Context.js
+++ b/src/core/Context.js
@@ -134,9 +134,13 @@ define(function(require, exports, module) {
     Context.prototype.migrate = function migrate(container) {
         if (container === this.container) return;
         _removeEventListeners.call(this, this.container);
+        this.container.classList.remove('famous-root');
+
         this.container = container;
+
         this._allocator.migrate(container);
         _addEventListeners.call(this, this.container);
+        this.container.classList.add('famous-root');
     };
 
     /**

--- a/src/core/Context.js
+++ b/src/core/Context.js
@@ -216,7 +216,6 @@ define(function(require, exports, module) {
      *
      * @param {string} type event type key (for example, 'click')
      * @param {function(string, Object)} handler callback
-     * @return {EventHandler} this
      */
     Context.prototype.on = function on(type, handler) {
         if (this.container) this.container.addEventListener(type, this.eventForwarder);

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -122,16 +122,6 @@ define(function(require, exports, module) {
     window.addEventListener('resize', handleResize, false);
     handleResize();
 
-    function addRootClasses() {
-        if (!document.body) {
-            Engine.nextTick(addRootClasses);
-            return;
-        }
-
-        document.body.classList.add('famous-root');
-        document.documentElement.classList.add('famous-root');
-    }
-
     /**
      * Add event handler object to set of downstream handlers.
      *
@@ -282,8 +272,6 @@ define(function(require, exports, module) {
      * @return {Context} new Context within el
      */
     Engine.createContext = function createContext(el) {
-        if (options.appMode) Engine.nextTick(addRootClasses);
-
         var needMountContainer = false;
         if (!el) {
             el = document.createElement(options.containerType);
@@ -291,7 +279,7 @@ define(function(require, exports, module) {
             needMountContainer = true;
         }
 
-        var context = new Context(el);
+        var context = new Context(el, options.appMode);
         Engine.registerContext(context);
 
         if (needMountContainer) mount(context, el);

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -18,9 +18,6 @@ define(function(require, exports, module) {
      *   On static initialization, window.requestAnimationFrame is called with
      *     the event loop function.
      *
-     *   Note: Any window in which Engine runs will prevent default
-     *     scrolling behavior on the 'touchmove' event.
-     *
      * @static
      * @class Engine
      */
@@ -124,23 +121,6 @@ define(function(require, exports, module) {
     }
     window.addEventListener('resize', handleResize, false);
     handleResize();
-
-    /**
-     * Initialize famous for app mode
-     *
-     * @static
-     * @private
-     * @method initialize
-     */
-    function initialize() {
-        // prevent scrolling via browser
-        window.addEventListener('touchmove', function(event) {
-            event.preventDefault();
-        }, true);
-
-        addRootClasses();
-    }
-    var initialized = false;
 
     function addRootClasses() {
         if (!document.body) {
@@ -302,7 +282,7 @@ define(function(require, exports, module) {
      * @return {Context} new Context within el
      */
     Engine.createContext = function createContext(el) {
-        if (!initialized && options.appMode) Engine.nextTick(initialize);
+        if (options.appMode) Engine.nextTick(addRootClasses);
 
         var needMountContainer = false;
         if (!el) {


### PR DESCRIPTION
[Working PR] The Context should initialize itself, adding any listeners or classes directly to its container.  On any migration of context, the old context can be cleaned up and the new context can be initialized in the same manner.

The Context's container should be considered a self contained node.  There shouldn't be any configuration, listeners, etc. above the the Context's container.  **Realistically, the Context shouldn't know about anything outside of its container and the Engine shouldn't know about anything outside of its Contexts.**

When there is "reaching" out of the context, it becomes a real problem for apps that only use Famous in certain areas.

Theme's:
- All event listeners and classes are attached to the individual context container
- Use practices from `ElementOutput` to forward events ensuring no leaks
