### PR TITLE
fix: ScrollView resize not working as expected with [undefined,true] siz...

### DIFF
--- a/src/core/Surface.js
+++ b/src/core/Surface.js
@@ -377,6 +377,12 @@ define(function(require, exports, module) {
 
         if (_xyNotEquals(this._size, size)) {
             if (!this._size) this._size = [0, 0];
+            if (this.size) {
+                if ((this.size[0] === true && this._size[1] !== size[1]) ||
+                    (this.size[1] === true && this._size[0] !== size[0])) {
+                    this._trueSizeCheck = true;
+                }
+            }
             this._size[0] = size[0];
             this._size[1] = size[1];
 

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -122,7 +122,6 @@ define(function(require, exports, module) {
         this._touchVelocity = 0;
         this._earlyEnd = false;
         this._needsPaginationCheck = false;
-        this._displacement = 0;
         this._totalShift = 0;
         this._cachedIndex = 0;
         this._lastSizeForDirection = 0;
@@ -208,7 +207,6 @@ define(function(require, exports, module) {
         }
 
         this.setPosition(this.getPosition() + delta);
-        this._displacement += delta;
 
         if (this._springState === SpringStates.NONE) _normalizeState.call(this);
     }
@@ -265,7 +263,6 @@ define(function(require, exports, module) {
 
         this._particle.on('update', function(particle) {
             if (this._springState === SpringStates.NONE) _normalizeState.call(this);
-            this._displacement = particle.position.x - this._totalShift;
         }.bind(this));
 
         this._particle.on('end', function() {

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -125,6 +125,7 @@ define(function(require, exports, module) {
         this._displacement = 0;
         this._totalShift = 0;
         this._cachedIndex = 0;
+        this._lastSizeForDirection = 0;
 
         // subcomponent logic
         this._scroller.positionFrom(this.getPosition.bind(this));
@@ -236,6 +237,18 @@ define(function(require, exports, module) {
 
         this._eventInput.on('resize', function() {
             this._node._.calculateSize();
+            var position = this.getPosition();
+            var sizeForDirection = _nodeSizeForDirection.call(this, this._node);
+            if (position) {
+                var clipSize = this._scroller.getSize()[this.options.direction];
+                var posRatio = position / (this._lastSizeForDirection - clipSize);
+                var newPosition = (sizeForDirection - clipSize) * posRatio;
+                if (position !== newPosition) {
+                    this.setPosition(newPosition);
+                    this._displacement = newPosition;
+                }
+            }
+            this._lastSizeForDirection = sizeForDirection;
         }.bind(this));
 
         this._scroller.on('onEdge', function(data) {

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -241,7 +241,8 @@ define(function(require, exports, module) {
             var sizeForDirection = _nodeSizeForDirection.call(this, this._node);
             if (position) {
                 var clipSize = this._scroller.getSize()[this.options.direction];
-                var posRatio = position / (this._lastSizeForDirection - clipSize);
+                var prevMaxRange = this._lastSizeForDirection - clipSize;
+                var posRatio = (prevMaxRange > 0) ? position / prevMaxRange : 1;
                 var newPosition = (sizeForDirection - clipSize) * posRatio;
                 if (position !== newPosition) {
                     this.setPosition(newPosition);

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -640,6 +640,9 @@ define(function(require, exports, module) {
      */
     Scrollview.prototype.sequenceFrom = function sequenceFrom(node) {
         if (node instanceof Array) node = new ViewSequence({array: node, trackSize: true});
+        this._lastSizeForDirection = 0;
+        this._lastClipSize = 0;
+        this.setOffset(0);
         this._node = node;
         return this._scroller.sequenceFrom(node);
     };

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -126,6 +126,7 @@ define(function(require, exports, module) {
         this._totalShift = 0;
         this._cachedIndex = 0;
         this._lastSizeForDirection = 0;
+        this._lastClipSize = 0;
 
         // subcomponent logic
         this._scroller.positionFrom(this.getPosition.bind(this));
@@ -237,19 +238,17 @@ define(function(require, exports, module) {
 
         this._eventInput.on('resize', function() {
             this._node._.calculateSize();
-            var position = this.getPosition();
+            var offset = this.getOffset();
             var sizeForDirection = _nodeSizeForDirection.call(this, this._node);
-            if (position) {
-                var clipSize = this._scroller.getSize()[this.options.direction];
-                var prevMaxRange = this._lastSizeForDirection - clipSize;
-                var posRatio = (prevMaxRange > 0) ? position / prevMaxRange : 1;
-                var newPosition = (sizeForDirection - clipSize) * posRatio;
-                if (position !== newPosition) {
-                    this.setPosition(newPosition);
-                    this._displacement = newPosition;
-                }
+            var clipSize = this._scroller.getSize()[this.options.direction];
+            if (offset) {
+                var lastMaxRange = this._lastSizeForDirection - this._lastClipSize;
+                var offsetRatio = (lastMaxRange > 0) ? offset / lastMaxRange : 1;
+                var newOffset = (sizeForDirection - clipSize) * offsetRatio;
+                if (offset !== newOffset) this.setOffset(newOffset);
             }
             this._lastSizeForDirection = sizeForDirection;
+            this._lastClipSize = clipSize;
         }.bind(this));
 
         this._scroller.on('onEdge', function(data) {


### PR DESCRIPTION
attempt to fix #681 

(1) Code that depends on surface size (ViewSequence.Backing.calculateSize()) can fail due to resize events that break internal size state of surfaces with size of [undefined,true] or [true, undefined]. Tweaked Surface to schedule a true size check after a size change in the opposite dimension.

(2) ScrollView position state can break when its ViewSequence scales. Added repositioning magic to resize handler to sync state.

Can look funky chunky when ScrollView repositions to catch up with scaling while positioned at the bottom of the scroll range. Wonder if this is avoidable.
