### PR TITLE
Calculate particle deltas

### DIFF
--- a/src/physics/bodies/Body.js
+++ b/src/physics/bodies/Body.js
@@ -230,7 +230,7 @@ define(function(require, exports, module) {
 
         var delta = this.angularMomentumDelta = Integrator.integrateAngularMomentum(t, dt);
         if (delta) {
-            L.add(delta).put(L);
+            delta.add(L);
             t.clear();
         }
     };
@@ -248,7 +248,7 @@ define(function(require, exports, module) {
 
         var delta = this.orientationDelta = Integrator.integrateOrientation(q, w, dt);
         if (delta) {
-            q.add(delta).put(q);
+            delta.add(q);
             // q.normalize.put(q);
         }
     };

--- a/src/physics/bodies/Body.js
+++ b/src/physics/bodies/Body.js
@@ -55,18 +55,6 @@ define(function(require, exports, module) {
 
     Body.prototype.isBody = true;
 
-    /**
-     * Stops the particle from updating
-     *
-     * @method sleep
-     */
-    Body.prototype.sleep = function sleep() {
-        Particle.prototype.sleep.call(this);
-
-        this.angularMomentumDelta = undefined;
-        this.positionDelta = undefined;
-    };
-
     Body.prototype.setMass = function setMass() {
         Particle.prototype.setMass.apply(this, arguments);
         this.setMomentsOfInertia();
@@ -230,7 +218,7 @@ define(function(require, exports, module) {
 
         var delta = this.angularMomentumDelta = Integrator.integrateAngularMomentum(t, dt);
         if (delta) {
-            delta.add(L);
+            L.add(delta).put(L);
             t.clear();
         }
     };
@@ -248,7 +236,7 @@ define(function(require, exports, module) {
 
         var delta = this.orientationDelta = Integrator.integrateOrientation(q, w, dt);
         if (delta) {
-            delta.add(q);
+            q.add(delta).put(q);
             // q.normalize.put(q);
         }
     };

--- a/src/physics/bodies/Body.js
+++ b/src/physics/bodies/Body.js
@@ -246,7 +246,7 @@ define(function(require, exports, module) {
         var q = this.orientation;
         var w = this.angularVelocity;
 
-        var delta = this.orientationDelta = Integrator.integrateOrientation();
+        var delta = this.orientationDelta = Integrator.integrateOrientation(q, w, dt);
         if (delta) {
             q.add(delta).put(q);
             // q.normalize.put(q);

--- a/src/physics/bodies/Particle.js
+++ b/src/physics/bodies/Particle.js
@@ -295,7 +295,7 @@ define(function(require, exports, module) {
         var delta = this.velocityDelta = Integrator.integrateVelocity(f, w, dt);
         if (delta) {
             f.clear();
-            v.add(delta).put(v);
+            delta.add(v);
         }
     };
 
@@ -321,7 +321,7 @@ define(function(require, exports, module) {
         var v = this.velocity;
 
         var delta = this.positionDelta = Integrator.integratePosition(v, dt);
-        if (delta) p.add(delta).put(p);
+        if (delta) delta.add(p);
     };
 
     /*

--- a/src/physics/bodies/Particle.js
+++ b/src/physics/bodies/Particle.js
@@ -109,9 +109,6 @@ define(function(require, exports, module) {
         if (this._isSleeping) return;
         this.emit(_events.end, this);
         this._isSleeping = true;
-
-        this.velocityDelta = undefined;
-        this.positionDelta = undefined;
     };
 
     /**
@@ -295,7 +292,7 @@ define(function(require, exports, module) {
         var delta = this.velocityDelta = Integrator.integrateVelocity(f, w, dt);
         if (delta) {
             f.clear();
-            delta.add(v);
+            v.add(delta).put(v);
         }
     };
 
@@ -306,7 +303,8 @@ define(function(require, exports, module) {
      * @function
      */
     Particle.prototype.getVelocityDelta = function getVelocityDelta() {
-        return this.velocityDelta;
+        if (this.velocityDelta) return this.velocityDelta.get();
+        return undefined;
     };
 
     /**
@@ -321,7 +319,7 @@ define(function(require, exports, module) {
         var v = this.velocity;
 
         var delta = this.positionDelta = Integrator.integratePosition(v, dt);
-        if (delta) delta.add(p);
+        if (delta) p.add(delta).put(p);
     };
 
     /*
@@ -331,7 +329,9 @@ define(function(require, exports, module) {
      * @function
      */
     Particle.prototype.getPositionDelta = function getPositionDelta() {
-        return this.positionDelta;
+        this._engine.step();
+        if (this.positionDelta) return this.positionDelta.get();
+        return undefined;
     };
 
     /**

--- a/src/physics/bodies/Particle.js
+++ b/src/physics/bodies/Particle.js
@@ -301,7 +301,7 @@ define(function(require, exports, module) {
 
     /*
      * Returns the last integrated velocity delta
-     * 
+     *
      * @method getVelocityDelta
      * @function
      */
@@ -317,8 +317,8 @@ define(function(require, exports, module) {
      * @param dt {Number} Time differential
      */
     Particle.prototype.integratePosition = function integratePosition(dt) {
-        var p = body.position;
-        var v = body.velocity;
+        var p = this.position;
+        var v = this.velocity;
 
         var delta = this.positionDelta = Integrator.integratePosition(this, dt);
         if (delta) p.add(delta).put(p);
@@ -326,7 +326,7 @@ define(function(require, exports, module) {
 
     /*
      * Returns the last integrated velocity delta
-     * 
+     *
      * @method getVelocityDelta
      * @function
      */

--- a/src/physics/bodies/Particle.js
+++ b/src/physics/bodies/Particle.js
@@ -320,7 +320,7 @@ define(function(require, exports, module) {
         var p = this.position;
         var v = this.velocity;
 
-        var delta = this.positionDelta = Integrator.integratePosition(this, dt);
+        var delta = this.positionDelta = Integrator.integratePosition(v, dt);
         if (delta) p.add(delta).put(p);
     };
 

--- a/src/physics/integrators/SymplecticEuler.js
+++ b/src/physics/integrators/SymplecticEuler.js
@@ -34,18 +34,14 @@ define(function(require, exports, module) {
      *      v <- v + dt * f / m
      *
      * @method integrateVelocity
-     * @param {Body} physics body
+     * @param {Vector} f external force
+     * @param {Number} w inverse mass
      * @param {Number} dt delta time
      */
-    SymplecticEuler.integrateVelocity = function integrateVelocity(body, dt) {
-        var v = body.velocity;
-        var w = body.inverseMass;
-        var f = body.force;
-
+    SymplecticEuler.integrateVelocity = function integrateVelocity(f, w, dt) {
         if (f.isZero()) return;
-
-        v.add(f.mult(dt * w)).put(v);
-        f.clear();
+        
+        return f.mult(dt * w);
     };
 
     /*

--- a/src/physics/integrators/SymplecticEuler.js
+++ b/src/physics/integrators/SymplecticEuler.js
@@ -30,8 +30,8 @@ define(function(require, exports, module) {
     var SymplecticEuler = {};
 
     /*
-     * Updates the velocity of a physics body from its accumulated force.
-     *      v <- v + dt * f / m
+     * Calculates the change in velocity of a physics body from its accumulated force.
+     *      dt * f / m
      *
      * @method integrateVelocity
      * @param {Vector} f external force
@@ -45,53 +45,44 @@ define(function(require, exports, module) {
     };
 
     /*
-     * Updates the position of a physics body from its velocity.
-     *      p <- p + dt * v
+     * Calculates the change in position of a physics body from its velocity.
+     *      dt * v
      *
      * @method integratePosition
-     * @param {Body} physics body
+     * @param {Vector} v body velocity
      * @param {Number} dt delta time
      */
-    SymplecticEuler.integratePosition = function integratePosition(body, dt) {
-        var p = body.position;
-        var v = body.velocity;
-
-        p.add(v.mult(dt)).put(p);
+    SymplecticEuler.integratePosition = function integratePosition(v, dt) {
+        return v.mult(dt);
     };
 
     /*
-     * Updates the angular momentum of a physics body from its accumuled torque.
-     *      L <- L + dt * t
+     * Calculates the change in angular momentum of a physics body from its accumuled torque.
+     *      dt * t
      *
      * @method integrateAngularMomentum
-     * @param {Body} physics body (except a particle)
+     * @param {Vector} t body torque
      * @param {Number} dt delta time
      */
-    SymplecticEuler.integrateAngularMomentum = function integrateAngularMomentum(body, dt) {
-        var L = body.angularMomentum;
-        var t = body.torque;
-
+    SymplecticEuler.integrateAngularMomentum = function integrateAngularMomentum(t, dt) {
         if (t.isZero()) return;
 
-        L.add(t.mult(dt)).put(L);
-        t.clear();
+        return t.mult(dt);
     };
 
     /*
-     * Updates the orientation of a physics body from its angular velocity.
-     *      q <- q + dt/2 * q * w
+     * Calculates the change in orientation of a physics body from its angular velocity.
+     *      dt/2 * q * w
      *
      * @method integrateOrientation
-     * @param {Body} physics body (except a particle)
+     * @param {Matrix} q body orientation
+     * @param {Matrix} w body angular velocity
      * @param {Number} dt delta time
      */
-    SymplecticEuler.integrateOrientation = function integrateOrientation(body, dt) {
-        var q = body.orientation;
-        var w = body.angularVelocity;
-
+    SymplecticEuler.integrateOrientation = function integrateOrientation(q, w, dt) {
         if (w.isZero()) return;
-        q.add(q.multiply(w).scalarMultiply(0.5 * dt)).put(q);
-//        q.normalize.put(q);
+
+        return q.multiply(w).scalarMultiply(0.5 * dt);
     };
 
     module.exports = SymplecticEuler;

--- a/src/physics/integrators/SymplecticEuler.js
+++ b/src/physics/integrators/SymplecticEuler.js
@@ -8,6 +8,7 @@
  */
 
 define(function(require, exports, module) {
+    var Vector = require('../../math/Vector');
 
     /**
      * Ordinary Differential Equation (ODE) Integrator.
@@ -42,7 +43,9 @@ define(function(require, exports, module) {
     SymplecticEuler.integrateVelocity = function integrateVelocity(f, w, dt) {
         if (f.isZero()) return null;
 
-        return f.mult(dt * w);
+        var delta = new Vector();
+        f.mult(dt * w).put(delta);
+        return delta;
     };
 
     /*
@@ -55,7 +58,9 @@ define(function(require, exports, module) {
      * @return {Vector} delta
      */
     SymplecticEuler.integratePosition = function integratePosition(v, dt) {
-        return v.mult(dt);
+        var delta = new Vector();
+        v.mult(dt).put(delta);
+        return delta;
     };
 
     /*
@@ -70,7 +75,9 @@ define(function(require, exports, module) {
     SymplecticEuler.integrateAngularMomentum = function integrateAngularMomentum(t, dt) {
         if (t.isZero()) return null;
 
-        return t.mult(dt);
+        var delta = new Vector();
+        t.mult(dt).put(delta);
+        return delta;
     };
 
     /*
@@ -86,7 +93,9 @@ define(function(require, exports, module) {
     SymplecticEuler.integrateOrientation = function integrateOrientation(q, w, dt) {
         if (w.isZero()) return null;
 
-        return q.multiply(w).scalarMultiply(0.5 * dt);
+        var delta = new Vector();
+        q.multiply(w).scalarMultiply(0.5 * dt).put(delta);
+        return delta;
     };
 
     module.exports = SymplecticEuler;

--- a/src/physics/integrators/SymplecticEuler.js
+++ b/src/physics/integrators/SymplecticEuler.js
@@ -40,7 +40,7 @@ define(function(require, exports, module) {
      * @return {Vector} delta or null if no force
      */
     SymplecticEuler.integrateVelocity = function integrateVelocity(f, w, dt) {
-        if (f.isZero()) return;
+        if (f.isZero()) return null;
 
         return f.mult(dt * w);
     };

--- a/src/physics/integrators/SymplecticEuler.js
+++ b/src/physics/integrators/SymplecticEuler.js
@@ -37,10 +37,11 @@ define(function(require, exports, module) {
      * @param {Vector} f external force
      * @param {Number} w inverse mass
      * @param {Number} dt delta time
+     * @return {Vector} delta or null if no force
      */
     SymplecticEuler.integrateVelocity = function integrateVelocity(f, w, dt) {
         if (f.isZero()) return;
-        
+
         return f.mult(dt * w);
     };
 
@@ -51,6 +52,7 @@ define(function(require, exports, module) {
      * @method integratePosition
      * @param {Vector} v body velocity
      * @param {Number} dt delta time
+     * @return {Vector} delta
      */
     SymplecticEuler.integratePosition = function integratePosition(v, dt) {
         return v.mult(dt);
@@ -63,9 +65,10 @@ define(function(require, exports, module) {
      * @method integrateAngularMomentum
      * @param {Vector} t body torque
      * @param {Number} dt delta time
+     * @return {Vector} delta or null if no torque
      */
     SymplecticEuler.integrateAngularMomentum = function integrateAngularMomentum(t, dt) {
-        if (t.isZero()) return;
+        if (t.isZero()) return null;
 
         return t.mult(dt);
     };
@@ -78,9 +81,10 @@ define(function(require, exports, module) {
      * @param {Matrix} q body orientation
      * @param {Matrix} w body angular velocity
      * @param {Number} dt delta time
+     * @return {Vector} delta or null if no angular velocity
      */
     SymplecticEuler.integrateOrientation = function integrateOrientation(q, w, dt) {
-        if (w.isZero()) return;
+        if (w.isZero()) return null;
 
         return q.multiply(w).scalarMultiply(0.5 * dt);
     };


### PR DESCRIPTION
The physics engine should calculate and store the deltas for each integral.  Since it is not possible to integrate in the direction of a specific force (x vs y instead of x&y), it is necessary to split the forces onto separate particles and then sum the delta of the forces to achieve the desired result.
