### PR TITLE
Bug Fixed: DEFAULT_OPTIONS not working 

### DIFF
--- a/src/views/DrawerLayout.js
+++ b/src/views/DrawerLayout.js
@@ -38,7 +38,7 @@ define(function(require, exports, module) {
      * @param [options.transition=true] {Boolean|Object}        The toggle transition
      */
     function DrawerLayout(options) {
-        this.options = Object.create(DrawerLayout.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || DrawerLayout.DEFAULT_OPTIONS);
         this._optionsManager = new OptionsManager(this.options);
         if (options) this.setOptions(options);
 

--- a/src/views/FlexibleLayout.js
+++ b/src/views/FlexibleLayout.js
@@ -26,7 +26,7 @@ define(function(require, exports, module) {
      * @param {Ratios} [options.ratios=[]] The proportions for the renderables to maintain
      */
     function FlexibleLayout(options) {
-        this.options = Object.create(FlexibleLayout.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || FlexibleLayout.DEFAULT_OPTIONS);
         this.optionsManager = new OptionsManager(this.options);
         if (options) this.setOptions(options);
 

--- a/src/views/Flipper.js
+++ b/src/views/Flipper.js
@@ -25,7 +25,7 @@ define(function(require, exports, module) {
      * @param {Direction} [options.direction=Flipper.DIRECTION_X] Direction specifies the axis of rotation.
      */
     function Flipper(options) {
-        this.options = Object.create(Flipper.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || Flipper.DEFAULT_OPTIONS);
         this._optionsManager = new OptionsManager(this.options);
         if (options) this.setOptions(options);
 

--- a/src/views/GridLayout.js
+++ b/src/views/GridLayout.js
@@ -33,7 +33,7 @@ define(function(require, exports, module) {
      * @param {Transition} [options.transition=false] The transiton that controls the Gridlayout instance's reflow.
      */
     function GridLayout(options) {
-        this.options = Object.create(GridLayout.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || GridLayout.DEFAULT_OPTIONS);
         this.optionsManager = new OptionsManager(this.options);
         if (options) this.setOptions(options);
 

--- a/src/views/HeaderFooterLayout.js
+++ b/src/views/HeaderFooterLayout.js
@@ -28,7 +28,7 @@ define(function(require, exports, module) {
      * in the HeaderFooterLayout instance's direction.
      */
     function HeaderFooterLayout(options) {
-        this.options = Object.create(HeaderFooterLayout.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || HeaderFooterLayout.DEFAULT_OPTIONS);
         this._optionsManager = new OptionsManager(this.options);
         if (options) this.setOptions(options);
 

--- a/src/views/Lightbox.js
+++ b/src/views/Lightbox.js
@@ -43,7 +43,7 @@ define(function(require, exports, module) {
       *  or synchronously beforehand.
      */
     function Lightbox(options) {
-        this.options = Object.create(Lightbox.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || Lightbox.DEFAULT_OPTIONS);
         this._optionsManager = new OptionsManager(this.options);
 
         if (options) this.setOptions(options);

--- a/src/views/ScrollContainer.js
+++ b/src/views/ScrollContainer.js
@@ -26,7 +26,7 @@ define(function(require, exports, module) {
      * @param {Options} [options.scrollview={direction:Utility.Direction.X}]  Options for the ScrollContainer instance's scrollview.
      */
     function ScrollContainer(options) {
-        this.options = Object.create(ScrollContainer.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || ScrollContainer.DEFAULT_OPTIONS);
         this._optionsManager = new OptionsManager(this.options);
 
         if (options) this.setOptions(options);

--- a/src/views/Scroller.js
+++ b/src/views/Scroller.js
@@ -23,7 +23,7 @@ define(function(require, exports, module) {
      * @param {Number} [margin=undefined] The size of the area (in pixels) that Scroller will process renderables' associated calculations in.
      */
     function Scroller(options) {
-        this.options = Object.create(this.constructor.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || Scroller.DEFAULT_OPTIONS);
         this._optionsManager = new OptionsManager(this.options);
         if (options) this._optionsManager.setOptions(options);
 

--- a/src/views/Scrollview.js
+++ b/src/views/Scrollview.js
@@ -76,7 +76,7 @@ define(function(require, exports, module) {
      */
     function Scrollview(options) {
         // patch options with defaults
-        this.options = Object.create(Scrollview.DEFAULT_OPTIONS);
+        this.options = Object.create(this.constructor.DEFAULT_OPTIONS || Scrollview.DEFAULT_OPTIONS);
         this._optionsManager = new OptionsManager(this.options);
 
         // create sub-components


### PR DESCRIPTION
Bug Fixed: DEFAULT_OPTIONS not working when customzing man kinds of views. Besides ==> I find most of classes doesn't consider `this.constructor.DEFAULT_OPTIONS`, that means it could not specific default values when extending those class. Consider about it~ Thx~
