### PR TITLE
Bug causing slow/spikey animation performance issues with slow animations

### DIFF
--- a/src/core/ElementOutput.js
+++ b/src/core/ElementOutput.js
@@ -158,8 +158,16 @@ define(function(require, exports, module) {
      * @return {string} matrix3d CSS style representation of the transform
      */
     function _formatCSSTransform(m) {
-        m[12] = Math.round(m[12] * devicePixelRatio) / devicePixelRatio;
-        m[13] = Math.round(m[13] * devicePixelRatio) / devicePixelRatio;
+        var deviceWidth = window.orientation === 0 ? window.screen.width : window.screen.height;
+        var deviceHeight = window.orientation === 0 ? window.screen.height : window.screen.width;
+        // iOS returns logical pixels, Android returns physical pixels
+        // http://www.quirksmode.org/blog/archives/2012/07/more_about_devi.html
+        if (navigator.userAgent.indexOf('iPhone') >= 0 && window.devicePixelRatio) {
+          deviceWidth = deviceWidth * window.devicePixelRatio;
+          deviceHeight = deviceHeight * window.devicePixelRatio;
+        }
+        m[12] = Math.round(m[12] * deviceWidth) / deviceWidth;
+        m[13] = Math.round(m[13] * deviceHeight) / deviceHeight;
 
         var result = 'matrix3d(';
         for (var i = 0; i < 15; i++) {


### PR DESCRIPTION
I think I've come across a bug which causes performance issues on slow animations.
An example is here:
Bug: http://jsbin.com/riwimejewi/1/
Hacked Fix: http://jsbin.com/riwimejewi/2/

If you place the animations side by side, you should be able to notice that the fixed one is smoother.
This is caused by the _formatCSSTransform method in the ElementOutput class. Line 168/170 rounds off the x and y values of the 3D transform using:

  m[12] = Math.round(m[12] \* devicePixelRatio) / devicePixelRatio;
  m[13] = Math.round(m[13] \* devicePixelRatio) / devicePixelRatio;

I suppose the intention here was to round the values to match the screen's actual pixels, but it is rounding based on only the devicePixelRatio and not the screen size. A screen with 200 pixels should round differently to one with 2000 pixels?

I've made a pull request for a simple fix, though I haven't tested this fix thoroughly, or on different devices.
